### PR TITLE
Remove WP Forms notice from GS content area

### DIFF
--- a/dist/getting-started/getting-started.css
+++ b/dist/getting-started/getting-started.css
@@ -964,6 +964,10 @@
 	width: 100%;
 }
 
+.ab-block-split-left .notice {
+	display: none;
+}
+
 .ab-gutenberg-notice {
 	background: #f1f0ff;
 	border-radius: 5px;


### PR DESCRIPTION
Admin notices were showing up in the .ab-block-split-left div.