### PR TITLE
Notice block: Fix bug in Notice Display setting.

### DIFF
--- a/src/blocks/block-notice/components/button.js
+++ b/src/blocks/block-notice/components/button.js
@@ -5,14 +5,6 @@
 // Setup the block
 const { Component } = wp.element;
 
-// Register components
-const {
-	Button
-} = wp.components;
-
-// Import block dependencies and components
-import classnames from 'classnames';
-
 /**
  * Create a button wrapper Component
  */
@@ -23,13 +15,13 @@ export default class DismissButton extends Component {
 	}
 
 	render() {
-		
+
 		// Setup the attributes
 		const { attributes: { noticeTitleColor } } = this.props;
 
 		return (
-			<div 
-				className="ab-notice-dismiss" 
+			<div
+				className="ab-notice-dismiss"
 				style={ {
 					fill: noticeTitleColor,
 					color: noticeTitleColor,

--- a/src/blocks/block-notice/components/inspector.js
+++ b/src/blocks/block-notice/components/inspector.js
@@ -8,19 +8,13 @@ const { Component } = wp.element;
 
 // Import block components
 const {
-  BlockDescription,
-  ColorPalette,
   PanelColorSettings,
   InspectorControls,
 } = wp.editor;
 
 // Import Inspector components
 const {
-	Toolbar,
-	Button,
 	PanelBody,
-	PanelRow,
-	FormToggle,
 	RangeControl,
 	SelectControl,
 } = wp.components;
@@ -55,7 +49,7 @@ export default class Inspector extends Component {
 		];
 
 		// Setup the attributes
-		const { attributes: { noticeTitle, noticeContent, noticeAlignment, noticeBackgroundColor, noticeTextColor, noticeTitleColor, noticeFontSize, noticeDismiss } } = this.props;
+		const { attributes: { noticeBackgroundColor, noticeTextColor, noticeTitleColor, noticeFontSize, noticeDismiss } } = this.props;
 		const { setAttributes } = this.props;
 
 		// Update color values

--- a/src/blocks/block-notice/index.js
+++ b/src/blocks/block-notice/index.js
@@ -8,8 +8,6 @@ import Inspector from './components/inspector';
 import NoticeBox from './components/notice';
 import DismissButton from './components/button';
 import icons from './components/icons';
-import * as uniqueID from './../../utils/helper';
-import md5 from 'md5';
 
 // Import CSS
 import './styles/style.scss';
@@ -29,17 +27,7 @@ const {
 	RichText,
 	AlignmentToolbar,
 	BlockControls,
-	BlockAlignmentToolbar,
-	MediaUpload,
 } = wp.editor;
-
-// Register components
-const {
-	Button,
-	SelectControl,
-	withFallbackStyles,
-	withState,
-} = wp.components;
 
 class ABNoticeBlock extends Component {
 
@@ -52,25 +40,11 @@ class ABNoticeBlock extends Component {
 				noticeContent,
 				noticeAlignment,
 				noticeBackgroundColor,
-				noticeTextColor,
 				noticeTitleColor,
-				noticeFontSize,
 				noticeDismiss
 			},
-			attributes,
-			isSelected,
-			editable,
-			className,
 			setAttributes
 		} = this.props;
-
-		const onSelectImage = img => {
-			setAttributes( {
-				imgID: img.id,
-				imgURL: img.url,
-				imgAlt: img.alt,
-			} );
-		};
 
 		return [
 			// Show the alignment toolbar on focus
@@ -181,11 +155,8 @@ registerBlockType( 'atomic-blocks/ab-notice', {
 		const {
 			noticeTitle,
 			noticeContent,
-			noticeAlignment,
 			noticeBackgroundColor,
-			noticeTextColor,
 			noticeTitleColor,
-			noticeFontSize,
 			noticeDismiss
 		} = props.attributes;
 

--- a/src/blocks/block-notice/index.js
+++ b/src/blocks/block-notice/index.js
@@ -87,7 +87,7 @@ class ABNoticeBlock extends Component {
 			// Show the block markup in the editor
 			<NoticeBox { ...this.props }>
 				{	// Check if the notice is dismissible and output the button
-					noticeDismiss && (
+					( noticeDismiss && noticeDismiss === 'ab-dismissable' ) && (
 					<DismissButton { ...this.props }>
 						{ icons.dismiss }
 					</DismissButton>
@@ -192,7 +192,7 @@ registerBlockType( 'atomic-blocks/ab-notice', {
 		// Save the block markup for the front end
 		return (
 			<NoticeBox { ...props }>
-				{ noticeDismiss && (
+				{ ( noticeDismiss && noticeDismiss === 'ab-dismissable' ) && (
 					<DismissButton { ...props }>
 						{ icons.dismiss }
 					</DismissButton>


### PR DESCRIPTION
Fixes #118, where dismiss icon was showing no matter what option was selected.

This PR also includes fixes to remove unused components and functions throughout the block.