### PR TITLE
Remove ES6 syntax and jQuery dependency in dismiss.js #125

### DIFF
--- a/dist/assets/js/dismiss.js
+++ b/dist/assets/js/dismiss.js
@@ -1,22 +1,27 @@
-(function($) {
+/**
+ * Handles dismissible notices from the Notice block.
+ */
 
-	$(document).ready(function() {
+document.addEventListener( 'DOMContentLoaded', function() {
 
-		const elems = document.querySelectorAll('.ab-block-notice.ab-dismissable[data-id]');
-		elems.forEach(el => {
-			const uid = el.getAttribute( 'data-id' );
-			if ( ! localStorage.getItem(`notice-${uid}`) ) {
-				el.style.display = 'block';
-			}
+	var notices = document.querySelectorAll('.ab-block-notice.ab-dismissable[data-id]' );
 
-			if ( $( '.ab-notice-dismiss' ).length ) {
-				el.querySelector('.ab-notice-dismiss').addEventListener('click', () => {
-					localStorage.setItem(`notice-${uid}`, 1);
-					el.style.display = '';
-				})
-			}
-		})
+	notices.forEach( function( element ) {
 
-	});
+		var uid = element.getAttribute( 'data-id' );
 
-})(jQuery);
+		if ( ! localStorage.getItem('notice-' + uid ) ) {
+			element.style.display = 'block';
+		}
+
+		var dismissible = element.querySelector( '.ab-notice-dismiss' );
+
+		if ( dismissible ) {
+			dismissible.addEventListener( 'click', function( event ) {
+				event.preventDefault();
+				localStorage.setItem( 'notice-' + uid, '1' );
+				element.style.display = '';
+			} );
+		}
+	} );
+} );


### PR DESCRIPTION
In `dismiss.js`:
- Removes ES6 syntax
- Removes jQuery dependency

Closes #125.