### PR TITLE
Remove custom color palette in button block.

### DIFF
--- a/src/blocks/block-button/components/inspector.js
+++ b/src/blocks/block-button/components/inspector.js
@@ -12,21 +12,11 @@ const { Component } = wp.element;
 // Import block components
 const {
   InspectorControls,
-  BlockDescription,
-  ColorPalette,
-  PanelColorSettings,
 } = wp.editor;
 
 // Import Inspector components
 const {
-	Toolbar,
-	Button,
 	PanelBody,
-	PanelRow,
-	FormToggle,
-	RangeControl,
-	SelectControl,
-	ToggleControl,
 } = wp.components;
 
 /**
@@ -42,9 +32,6 @@ export default class Inspector extends Component {
 
 		// Setup the attributes
 		const {
-			buttonText,
-			buttonUrl,
-			buttonAlignment,
 			buttonBackgroundColor,
 			buttonTextColor,
 			buttonSize,

--- a/src/blocks/block-button/index.js
+++ b/src/blocks/block-button/index.js
@@ -6,7 +6,6 @@
 import classnames from 'classnames';
 import Inspector from './components/inspector';
 import CustomButton from './components/button';
-import icons from './components/icons';
 
 // Import CSS
 import './styles/style.scss';
@@ -26,14 +25,11 @@ const {
 	RichText,
 	AlignmentToolbar,
 	BlockControls,
-	BlockAlignmentToolbar,
 	URLInput,
 } = wp.editor;
 
 // Register components
 const {
-	Button,
-	withFallbackStyles,
 	IconButton,
 	Dashicon,
 } = wp.components;

--- a/src/utils/inspector/button.js
+++ b/src/utils/inspector/button.js
@@ -42,18 +42,6 @@ export default function ButtonSettings( props ) {
 		{ value: 'ab-button-shape-circular', label: __( 'Circular', 'atomic-blocks' ) },
 	];
 
-	// Button colors
-	const buttonColors = [
-		{ color: '#00d1b2', name: 'teal' },
-		{ color: '#3373dc', name: 'royal blue' },
-		{ color: '#209cef', name: 'sky blue' },
-		{ color: '#22d25f', name: 'green' },
-		{ color: '#ffdd57', name: 'yellow' },
-		{ color: '#ff3860', name: 'pink' },
-		{ color: '#7941b6', name: 'purple' },
-		{ color: '#392F43', name: 'black' },
-	];
-
 	return (
 		<Fragment>
 			{ enableButtonTarget != false && (
@@ -94,7 +82,6 @@ export default function ButtonSettings( props ) {
 						value: buttonBackgroundColor,
 						onChange: onChangeButtonColor,
 						label: __( 'Button Color', 'atomic-blocks' ),
-						colors: buttonColors,
 					} ] }
 				>
 				</PanelColorSettings>


### PR DESCRIPTION
Remove the plugin-defined color palette in favor of theme-defined color palettes.