### PR TITLE
Add className output to inner container on Advanced Columns

### DIFF
--- a/src/blocks/block-column-inner/deprecated/1.7.1/components/column.js
+++ b/src/blocks/block-column-inner/deprecated/1.7.1/components/column.js
@@ -15,7 +15,7 @@ import classnames from 'classnames';
 /**
  * Create a Columns wrapper Component.
  */
-export default class Column extends Component {
+export default class Column_1_7_1 extends Component {
 
 	constructor( props ) {
 		super( ...arguments );
@@ -86,7 +86,6 @@ export default class Column extends Component {
 		return (
 			<div
 				className={ classnames(
-					this.props.className,
 					'ab-block-layout-column',
 					attributes.columnVerticalAlignment ? 'ab-is-vertically-aligned-' + attributes.columnVerticalAlignment : null
 				) }

--- a/src/blocks/block-column-inner/deprecated/1.7.1/components/save.js
+++ b/src/blocks/block-column-inner/deprecated/1.7.1/components/save.js
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies.
+ */
+import Column_1_7_1 from './column';
+
+/**
+ * WordPress dependencies.
+ */
+const { Component } = wp.element;
+const { InnerBlocks } = wp.editor;
+
+export default class Save_1_7_1 extends Component {
+
+	render() {
+
+		const { attributes } = this.props;
+
+		return (
+			<Column_1_7_1
+				{ ...this.props }
+				/* Pass through the color attributes to the Column component */
+				backgroundColorValue={ attributes.backgroundColor ? null : attributes.customBackgroundColor }
+				textColorValue={ attributes.textColor ? null : attributes.customTextColor }
+			>
+				<InnerBlocks.Content />
+			</Column_1_7_1>
+		);
+	}
+}

--- a/src/blocks/block-column-inner/deprecated/deprecated.js
+++ b/src/blocks/block-column-inner/deprecated/deprecated.js
@@ -1,0 +1,90 @@
+/**
+ * Column component deprecations.
+ */
+
+import Save_1_7_1 from './1.7.1/components/save';
+
+export const Column_Inner_1_7_1_attributes = {
+	backgroundColor: {
+		type: 'string',
+	},
+	customBackgroundColor: {
+		type: 'string',
+	},
+	textColor: {
+		type: 'string',
+	},
+	customTextColor: {
+		type: 'string',
+	},
+	textAlign: {
+		type: 'string',
+	},
+	marginSync: {
+		type: 'boolean',
+		default: false,
+	},
+	marginUnit: {
+		type: 'string',
+		default: 'px',
+	},
+	margin: {
+		type: 'number',
+		default: 0,
+	},
+	marginTop: {
+		type: 'number',
+		default: 0,
+	},
+	marginBottom: {
+		type: 'number',
+		default: 0,
+	},
+	paddingSync: {
+		type: 'boolean',
+		default: false,
+	},
+	paddingUnit: {
+		type: 'string',
+		default: 'px',
+	},
+	padding: {
+		type: 'number',
+		default: 0,
+	},
+	paddingTop: {
+		type: 'number',
+		default: 0,
+	},
+	paddingRight: {
+		type: 'number',
+		default: 0,
+	},
+	paddingBottom: {
+		type: 'number',
+		default: 0,
+	},
+	paddingLeft: {
+		type: 'number',
+		default: 0,
+	},
+	columnVerticalAlignment: {
+		type: 'string',
+	},
+};
+
+export const Column_Inner_1_7_1_save = props => {
+	return (
+		<Save_1_7_1 { ...props } />
+	);
+}
+
+const deprecated = [
+	// Version 1.7.1
+	{
+		attributes: Column_Inner_1_7_1_attributes,
+		save: Column_Inner_1_7_1_save,
+	},
+];
+
+export default deprecated;

--- a/src/blocks/block-column-inner/index.js
+++ b/src/blocks/block-column-inner/index.js
@@ -7,6 +7,7 @@
  */
 import Edit from './components/edit';
 import Save from './components/save';
+import deprecated from './deprecated/deprecated';
 import './styles/style.scss';
 import './styles/editor.scss';
 
@@ -108,6 +109,8 @@ registerBlockType( 'atomic-blocks/ab-column', {
 	save: props => {
 		return <Save { ...props } />;
 	},
+
+	deprecated: deprecated,
 } );
 
 /* Add the vertical column alignment class to the block wrapper. */


### PR DESCRIPTION
- Deprecate old container save and column component
- Add this.props.className output

Fixes #119.

## How to test

This block required a deprecation, so we'll want to test a few different instances. Here's a quick reminder about how to test deprecations. 

- Switch to the master branch and create a test block
- Save the page
- Switch to the fix branch and regenerate assets with `npm run build-assets`
- Reload the page and check the status of the block 

In this deprecation, we added the `className` output to the block, so you should now see the Additional CSS Class output on each individual column. The block should also pass the content comparison and return without any invalid content warnings that break the block. 