### PR TITLE
Testimonial block: Add button to remove avatar in editor

### DIFF
--- a/src/blocks/block-testimonial/components/edit.js
+++ b/src/blocks/block-testimonial/components/edit.js
@@ -1,0 +1,167 @@
+/**
+ * Internal dependencies
+ */
+import classnames from 'classnames';
+import Inspector from './inspector';
+import Testimonial from './testimonial';
+import icons from './icons';
+
+/**
+ * WordPress dependencies
+ */
+const { __ } = wp.i18n;
+const {
+	Component,
+	Fragment
+} = wp.element;
+const {
+	RichText,
+	AlignmentToolbar,
+	BlockControls,
+	MediaUpload
+} = wp.editor;
+const {
+	Button,
+	Dashicon
+} = wp.components;
+
+const ALLOWED_MEDIA_TYPES = [ 'image' ];
+
+export default class Edit extends Component {
+	constructor() {
+		super( ...arguments );
+	}
+
+	render() {
+		// Setup the attributes
+		const {
+			attributes: {
+				testimonialName,
+				testimonialTitle,
+				testimonialContent,
+				testimonialAlignment,
+				testimonialImgURL,
+				testimonialImgID,
+				testimonialTextColor,
+			},
+			setAttributes
+		} = this.props;
+
+		const onSelectImage = img => {
+			setAttributes({
+				testimonialImgID: img.id,
+				testimonialImgURL: img.url
+			});
+		};
+
+		const onRemoveImage = () => {
+			setAttributes({
+				testimonialImgURL: null,
+				testimonialImgID: null,
+			});
+		}
+
+		return [
+
+			// Show the alignment toolbar on focus
+			<BlockControls key="controls">
+				<AlignmentToolbar
+					value={ testimonialAlignment }
+					onChange={ ( value ) => setAttributes({ testimonialAlignment: value }) }
+				/>
+			</BlockControls>,
+
+			// Show the block controls on focus
+			<Inspector
+				{ ...{ setAttributes, ...this.props } }
+			/>,
+
+			// Show the block markup in the editor
+			<Testimonial { ...this.props }>
+				<RichText
+					tagName="div"
+					multiline="p"
+					placeholder={ __( 'Add testimonial text...', 'atomic-blocks' ) }
+					keepPlaceholderOnFocus
+					value={ testimonialContent }
+					formattingControls={ [ 'bold', 'italic', 'strikethrough', 'link' ] }
+					className={ classnames(
+						'ab-testimonial-text'
+					) }
+					style={ {
+						textAlign: testimonialAlignment
+					} }
+					onChange={ ( value ) => setAttributes({ testimonialContent: value }) }
+				/>
+
+				<div className="ab-testimonial-info">
+					<div className="ab-testimonial-avatar-wrap">
+						<div className="ab-testimonial-image-wrap">
+							<MediaUpload
+								buttonProps={ {
+									className: 'change-image'
+								} }
+								onSelect={ ( img ) => setAttributes(
+									{
+										testimonialImgID: img.id,
+										testimonialImgURL: img.url
+									}
+								) }
+								allowed={ ALLOWED_MEDIA_TYPES }
+								type="image"
+								value={ testimonialImgID }
+								render={ ({ open }) => (
+									<Fragment>
+										<Button
+											className={ testimonialImgID ? 'ab-change-image' : 'ab-add-image' }
+											onClick={ open }
+										>
+											{ ! testimonialImgID ? icons.upload : <img
+												className="ab-testimonial-avatar"
+												src={ testimonialImgURL }
+												alt="avatar"
+											/>  }
+										</Button>
+										{ testimonialImgID && (
+											<Button
+												className="ab-remove-image"
+												onClick={ onRemoveImage }
+												>
+												<Dashicon icon={ 'dismiss' } />
+											</Button>
+										) }
+									</Fragment>
+								) }
+							>
+							</MediaUpload>
+						</div>
+					</div>
+
+					<RichText
+						tagName="h2"
+						placeholder={ __( 'Add name', 'atomic-blocks' ) }
+						keepPlaceholderOnFocus
+						value={ testimonialName }
+						className='ab-testimonial-name'
+						style={ {
+							color: testimonialTextColor
+						} }
+						onChange={ ( value ) => this.props.setAttributes({ testimonialName: value }) }
+					/>
+
+					<RichText
+						tagName="small"
+						placeholder={ __( 'Add title', 'atomic-blocks' ) }
+						keepPlaceholderOnFocus
+						value={ testimonialTitle }
+						className='ab-testimonial-title'
+						style={ {
+							color: testimonialTextColor
+						} }
+						onChange={ ( value ) => this.props.setAttributes({ testimonialTitle: value }) }
+					/>
+				</div>
+			</Testimonial>
+		];
+	}
+}

--- a/src/blocks/block-testimonial/components/edit.js
+++ b/src/blocks/block-testimonial/components/edit.js
@@ -33,6 +33,7 @@ export default class Edit extends Component {
 	}
 
 	render() {
+
 		// Setup the attributes
 		const {
 			attributes: {
@@ -42,24 +43,17 @@ export default class Edit extends Component {
 				testimonialAlignment,
 				testimonialImgURL,
 				testimonialImgID,
-				testimonialTextColor,
+				testimonialTextColor
 			},
 			setAttributes
 		} = this.props;
 
-		const onSelectImage = img => {
-			setAttributes({
-				testimonialImgID: img.id,
-				testimonialImgURL: img.url
-			});
-		};
-
 		const onRemoveImage = () => {
 			setAttributes({
 				testimonialImgURL: null,
-				testimonialImgID: null,
+				testimonialImgID: null
 			});
-		}
+		};
 
 		return [
 

--- a/src/blocks/block-testimonial/components/inspector.js
+++ b/src/blocks/block-testimonial/components/inspector.js
@@ -9,18 +9,12 @@ const { Component } = wp.element;
 // Import block components
 const {
 	InspectorControls,
-	BlockDescription,
-	ColorPalette,
 	PanelColorSettings
 } = wp.editor;
 
 // Import Inspector components
 const {
-	Toolbar,
-	Button,
 	PanelBody,
-	PanelRow,
-	FormToggle,
 	RangeControl,
 	SelectControl
 } = wp.components;
@@ -43,7 +37,7 @@ export default class Inspector extends Component {
 		];
 
 		// Setup the attributes
-		const { attributes: { testimonialName, testimonialTitle, testimonialContent, testimonialAlignment, testimonialImgURL, testimonialImgID, testimonialBackgroundColor, testimonialTextColor, testimonialFontSize, testimonialCiteAlign }, isSelected, className, setAttributes } = this.props;
+		const { attributes: { testimonialBackgroundColor, testimonialTextColor, testimonialFontSize, testimonialCiteAlign }, setAttributes } = this.props;
 
 		// Update color values
 		const onChangeBackgroundColor = value => setAttributes({ testimonialBackgroundColor: value });

--- a/src/blocks/block-testimonial/components/save.js
+++ b/src/blocks/block-testimonial/components/save.js
@@ -1,0 +1,77 @@
+/**
+ * Internal dependencies
+ */
+import Testimonial from './testimonial';
+
+/**
+ * WordPress dependencies
+ */
+const { Component } = wp.element;
+const { RichText } = wp.editor;
+
+export default class Save extends Component {
+	constructor() {
+		super( ...arguments );
+	}
+
+	render() {
+		const {
+			testimonialName,
+			testimonialTitle,
+			testimonialContent,
+			testimonialAlignment,
+			testimonialImgURL,
+			testimonialTextColor
+		} = this.props.attributes;
+
+		return (
+
+			<Testimonial { ...this.props }>
+				<RichText.Content
+					tagName="div"
+					className="ab-testimonial-text"
+					style={ {
+						textAlign: testimonialAlignment
+					} }
+					value={ testimonialContent }
+				/>
+
+				<div className="ab-testimonial-info">
+					{ testimonialImgURL && (
+						<div className="ab-testimonial-avatar-wrap">
+							<div className="ab-testimonial-image-wrap">
+								<img
+									className="ab-testimonial-avatar"
+									src={ testimonialImgURL }
+									alt="avatar"
+								/>
+							</div>
+						</div>
+					) }
+
+					{ testimonialName && (
+						<RichText.Content
+							tagName="h2"
+							className="ab-testimonial-name"
+							style={ {
+								color: testimonialTextColor
+							} }
+							value={ testimonialName }
+						/>
+					) }
+
+					{ testimonialTitle && (
+						<RichText.Content
+							tagName="small"
+							className="ab-testimonial-title"
+							style={ {
+								color: testimonialTextColor
+							} }
+							value={ testimonialTitle }
+						/>
+					) }
+				</div>
+			</Testimonial>
+		);
+	}
+}

--- a/src/blocks/block-testimonial/components/save.js
+++ b/src/blocks/block-testimonial/components/save.js
@@ -54,7 +54,7 @@ export default class Save extends Component {
 							tagName="h2"
 							className="ab-testimonial-name"
 							style={ {
-								color: testimonialTextColor
+								color: testimonialTextColor ? testimonialTextColor : '#32373c'
 							} }
 							value={ testimonialName }
 						/>
@@ -65,7 +65,7 @@ export default class Save extends Component {
 							tagName="small"
 							className="ab-testimonial-title"
 							style={ {
-								color: testimonialTextColor
+								color: testimonialTextColor ? testimonialTextColor : '#32373c'
 							} }
 							value={ testimonialTitle }
 						/>

--- a/src/blocks/block-testimonial/components/testimonial.js
+++ b/src/blocks/block-testimonial/components/testimonial.js
@@ -25,8 +25,8 @@ export default class Testimonial extends Component {
 		return (
 			<div
 				style={ {
-					backgroundColor: testimonialBackgroundColor,
-					color: testimonialTextColor
+					backgroundColor: testimonialBackgroundColor ? testimonialBackgroundColor : '#f2f2f2',
+					color: testimonialTextColor ? testimonialTextColor : '#32373c'
 				} }
 				className={ classnames(
 					this.props.className,

--- a/src/blocks/block-testimonial/components/testimonial.js
+++ b/src/blocks/block-testimonial/components/testimonial.js
@@ -7,7 +7,6 @@ const { Component } = wp.element;
 
 // Import block dependencies and components
 import classnames from 'classnames';
-import * as fontSize from './../../../utils/helper';
 
 /**
  * Create a Testimonial wrapper Component
@@ -21,7 +20,7 @@ export default class Testimonial extends Component {
 	render() {
 
 		// Setup the attributes
-		const { attributes: { testimonialAlignment, testimonialImgURL, testimonialBackgroundColor, testimonialTextColor, testimonialFontSize, testimonialCiteAlign }  } = this.props;
+		const { attributes: { testimonialImgURL, testimonialBackgroundColor, testimonialTextColor, testimonialFontSize, testimonialCiteAlign }  } = this.props;
 
 		return (
 			<div

--- a/src/blocks/block-testimonial/index.js
+++ b/src/blocks/block-testimonial/index.js
@@ -81,5 +81,5 @@ registerBlockType( 'atomic-blocks/ab-testimonial', {
 	/* Save the block markup. */
 	save: props => {
 		return <Save { ...props } />;
-	},
+	}
 });

--- a/src/blocks/block-testimonial/index.js
+++ b/src/blocks/block-testimonial/index.js
@@ -16,7 +16,7 @@ import './styles/editor.scss';
 const { __ } = wp.i18n;
 
 // Extend component
-const { Component } = wp.element;
+const { Component, Fragment } = wp.element;
 
 // Register block
 const { registerBlockType } = wp.blocks;
@@ -33,7 +33,8 @@ const {
 // Register components
 const {
 	Button,
-	SelectControl
+	SelectControl,
+	Dashicon
 } = wp.components;
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
@@ -69,6 +70,14 @@ class ABTestimonialBlock extends Component {
 				testimonialImgURL: img.url
 			});
 		};
+
+		const onRemoveImage = () => {
+			setAttributes({
+				testimonialImgURL: null,
+				testimonialImgID: null,
+				//imgAlt: null,
+			});
+		}
 
 		return [
 
@@ -120,13 +129,26 @@ class ABTestimonialBlock extends Component {
 								type="image"
 								value={ testimonialImgID }
 								render={ ({ open }) => (
-									<Button onClick={ open }>
-										{ ! testimonialImgID ? icons.upload : <img
-											className="ab-testimonial-avatar"
-											src={ testimonialImgURL }
-											alt="avatar"
-										/>  }
-									</Button>
+									<Fragment>
+										<Button
+											className={ testimonialImgID ? 'ab-change-image' : 'ab-add-image' }
+											onClick={ open }
+										>
+											{ ! testimonialImgID ? icons.upload : <img
+												className="ab-testimonial-avatar"
+												src={ testimonialImgURL }
+												alt="avatar"
+											/>  }
+										</Button>
+										{ testimonialImgID && (
+											<Button
+												className="ab-remove-image"
+												onClick={ onRemoveImage }
+												>
+												<Dashicon icon={ 'dismiss' } />
+											</Button>
+										) }
+									</Fragment>
 								) }
 							>
 							</MediaUpload>

--- a/src/blocks/block-testimonial/index.js
+++ b/src/blocks/block-testimonial/index.js
@@ -3,10 +3,8 @@
  */
 
 // Import block dependencies and components
-import classnames from 'classnames';
-import Inspector from './components/inspector';
-import Testimonial from './components/testimonial';
-import icons from './components/icons';
+import Edit from './components/edit';
+import Save from './components/save';
 
 // Import CSS
 import './styles/style.scss';
@@ -15,174 +13,8 @@ import './styles/editor.scss';
 // Internationalization
 const { __ } = wp.i18n;
 
-// Extend component
-const { Component, Fragment } = wp.element;
-
 // Register block
 const { registerBlockType } = wp.blocks;
-
-// Register editor components
-const {
-	RichText,
-	AlignmentToolbar,
-	BlockControls,
-	BlockAlignmentToolbar,
-	MediaUpload
-} = wp.editor;
-
-// Register components
-const {
-	Button,
-	SelectControl,
-	Dashicon
-} = wp.components;
-
-const ALLOWED_MEDIA_TYPES = [ 'image' ];
-
-class ABTestimonialBlock extends Component {
-
-	render() {
-
-		// Setup the attributes
-		const {
-			attributes: {
-				testimonialName,
-				testimonialTitle,
-				testimonialContent,
-				testimonialAlignment,
-				testimonialImgURL,
-				testimonialImgID,
-				testimonialBackgroundColor,
-				testimonialTextColor,
-				testimonialFontSize,
-				testimonialCiteAlign
-			},
-			attributes,
-			isSelected,
-			editable,
-			className,
-			setAttributes
-		} = this.props;
-
-		const onSelectImage = img => {
-			setAttributes({
-				testimonialImgID: img.id,
-				testimonialImgURL: img.url
-			});
-		};
-
-		const onRemoveImage = () => {
-			setAttributes({
-				testimonialImgURL: null,
-				testimonialImgID: null,
-				//imgAlt: null,
-			});
-		}
-
-		return [
-
-			// Show the alignment toolbar on focus
-			<BlockControls key="controls">
-				<AlignmentToolbar
-					value={ testimonialAlignment }
-					onChange={ ( value ) => setAttributes({ testimonialAlignment: value }) }
-				/>
-			</BlockControls>,
-
-			// Show the block controls on focus
-			<Inspector
-				{ ...{ setAttributes, ...this.props } }
-			/>,
-
-			// Show the block markup in the editor
-			<Testimonial { ...this.props }>
-				<RichText
-					tagName="div"
-					multiline="p"
-					placeholder={ __( 'Add testimonial text...', 'atomic-blocks' ) }
-					keepPlaceholderOnFocus
-					value={ testimonialContent }
-					formattingControls={ [ 'bold', 'italic', 'strikethrough', 'link' ] }
-					className={ classnames(
-						'ab-testimonial-text'
-					) }
-					style={ {
-						textAlign: testimonialAlignment
-					} }
-					onChange={ ( value ) => setAttributes({ testimonialContent: value }) }
-				/>
-
-				<div className="ab-testimonial-info">
-					<div className="ab-testimonial-avatar-wrap">
-						<div className="ab-testimonial-image-wrap">
-							<MediaUpload
-								buttonProps={ {
-									className: 'change-image'
-								} }
-								onSelect={ ( img ) => setAttributes(
-									{
-										testimonialImgID: img.id,
-										testimonialImgURL: img.url
-									}
-								) }
-								allowed={ ALLOWED_MEDIA_TYPES }
-								type="image"
-								value={ testimonialImgID }
-								render={ ({ open }) => (
-									<Fragment>
-										<Button
-											className={ testimonialImgID ? 'ab-change-image' : 'ab-add-image' }
-											onClick={ open }
-										>
-											{ ! testimonialImgID ? icons.upload : <img
-												className="ab-testimonial-avatar"
-												src={ testimonialImgURL }
-												alt="avatar"
-											/>  }
-										</Button>
-										{ testimonialImgID && (
-											<Button
-												className="ab-remove-image"
-												onClick={ onRemoveImage }
-												>
-												<Dashicon icon={ 'dismiss' } />
-											</Button>
-										) }
-									</Fragment>
-								) }
-							>
-							</MediaUpload>
-						</div>
-					</div>
-
-					<RichText
-						tagName="h2"
-						placeholder={ __( 'Add name', 'atomic-blocks' ) }
-						keepPlaceholderOnFocus
-						value={ testimonialName }
-						className='ab-testimonial-name'
-						style={ {
-							color: testimonialTextColor
-						} }
-						onChange={ ( value ) => this.props.setAttributes({ testimonialName: value }) }
-					/>
-
-					<RichText
-						tagName="small"
-						placeholder={ __( 'Add title', 'atomic-blocks' ) }
-						keepPlaceholderOnFocus
-						value={ testimonialTitle }
-						className='ab-testimonial-title'
-						style={ {
-							color: testimonialTextColor
-						} }
-						onChange={ ( value ) => this.props.setAttributes({ testimonialTitle: value }) }
-					/>
-				</div>
-			</Testimonial>
-		];
-	}
-}
 
 // Register the block
 registerBlockType( 'atomic-blocks/ab-testimonial', {
@@ -241,74 +73,13 @@ registerBlockType( 'atomic-blocks/ab-testimonial', {
         }
 	},
 
-	// Render the block components
-	edit: ABTestimonialBlock,
+	/* Render the block in the editor. */
+	edit: props => {
+		return <Edit { ...props } />;
+	},
 
-	// Save the attributes and markup
-	save: function( props ) {
-
-		// Setup the attributes
-		const {
-			testimonialName,
-			testimonialTitle,
-			testimonialContent,
-			testimonialAlignment,
-			testimonialImgURL,
-			testimonialImgID,
-			testimonialBackgroundColor,
-			testimonialTextColor,
-			testimonialFontSize,
-			testimonialCiteAlign
-		} = props.attributes;
-
-		// Save the block markup for the front end
-		return (
-			<Testimonial { ...props }>
-				<RichText.Content
-					tagName="div"
-					className="ab-testimonial-text"
-					style={ {
-						textAlign: testimonialAlignment
-					} }
-					value={ testimonialContent }
-				/>
-
-				<div className="ab-testimonial-info">
-					{ testimonialImgURL && (
-						<div className="ab-testimonial-avatar-wrap">
-							<div className="ab-testimonial-image-wrap">
-								<img
-									className="ab-testimonial-avatar"
-									src={ testimonialImgURL }
-									alt="avatar"
-								/>
-							</div>
-						</div>
-					) }
-
-					{ testimonialName && (
-						<RichText.Content
-							tagName="h2"
-							className="ab-testimonial-name"
-							style={ {
-								color: testimonialTextColor
-							} }
-							value={ testimonialName }
-						/>
-					) }
-
-					{ testimonialTitle && (
-						<RichText.Content
-							tagName="small"
-							className="ab-testimonial-title"
-							style={ {
-								color: testimonialTextColor
-							} }
-							value={ testimonialTitle }
-						/>
-					) }
-				</div>
-			</Testimonial>
-		);
-	}
+	/* Save the block markup. */
+	save: props => {
+		return <Save { ...props } />;
+	},
 });

--- a/src/blocks/block-testimonial/styles/editor.scss
+++ b/src/blocks/block-testimonial/styles/editor.scss
@@ -78,7 +78,7 @@
 	}
 }
 
-.ab-remove-image {
+.components-button.ab-remove-image {
 	color: #ec3939;
 	position: absolute;
     right: 0;
@@ -88,4 +88,16 @@
 	z-index: 60;
 	margin: 0;
 	padding: 0;
+	background: #fff;
+	border-radius: 50px;
+
+	&:active,
+	&:focus {
+		color: #ec3939;
+		background: #fff;
+	}
+}
+
+.ab-block-testimonial .ab-remove-image:not(:disabled):not([aria-disabled=true]):focus {
+	background: #fff;
 }

--- a/src/blocks/block-testimonial/styles/editor.scss
+++ b/src/blocks/block-testimonial/styles/editor.scss
@@ -28,3 +28,64 @@
         line-height: 1.8;
     }
 }
+
+#editor .ab-has-avatar {
+	.ab-testimonial-image-wrap {
+		.ab-change-image {
+			position: absolute;
+			z-index: 50;
+			padding: 0;
+			top: 0;
+			left: 0;
+			opacity: 1 !important;
+			height: 100%;
+		}
+
+		.ab-change-image:focus {
+			background: none;
+			border: none;
+			outline: none;
+			box-shadow: none;
+		}
+
+		&:hover {
+			cursor: pointer;
+
+			img {
+				opacity: .7;
+			}
+
+			.ab-change-image {
+				opacity: 1;
+			}
+		}
+	}
+}
+
+.ab-add-image {
+	position: absolute;
+	left: 0;
+	top: 0;
+	z-index: 50;
+	padding: 0;
+	width: 100%;
+	height: 100%;
+
+	svg {
+		position: absolute;
+		top: 17px;
+		left: 19px;
+	}
+}
+
+.ab-remove-image {
+	color: #ec3939;
+	position: absolute;
+    right: 0;
+    top: 0;
+    height: auto;
+	left: auto;
+	z-index: 60;
+	margin: 0;
+	padding: 0;
+}

--- a/src/blocks/block-testimonial/styles/style.scss
+++ b/src/blocks/block-testimonial/styles/style.scss
@@ -29,14 +29,14 @@
 		.ab-testimonial-avatar-wrap {
 			position: absolute;
 			left: 0;
-			top: 0; 
+			top: 0;
 		}
 	}
 
 	.ab-testimonial-avatar-wrap + .ab-testimonial-name,
 	.ab-testimonial-avatar-wrap + .ab-testimonial-name + .ab-testimonial-title,
 	.ab-testimonial-avatar-wrap + .ab-testimonial-title,
-	.ab-testimonial-avatar-wrap + .editor-rich-text, 
+	.ab-testimonial-avatar-wrap + .editor-rich-text,
 	.ab-testimonial-avatar-wrap + .editor-rich-text + .editor-rich-text {
 		margin-left: 70px;
 		padding-left: 0;
@@ -44,7 +44,7 @@
 
 	.ab-testimonial-text {
 		p {
-			line-height: 1.6; 
+			line-height: 1.6;
 		}
 
 		a {
@@ -63,7 +63,7 @@
 		font-size: 1em;
 		font-weight: bold;
 		line-height: 1.2;
-		margin: 0; 
+		margin: 0;
 		padding: 0;
 	}
 
@@ -80,23 +80,8 @@
 		height: 55px;
 		width: 55px;
 		background: #ddd;
-		border-radius: 200px; 
+		border-radius: 200px;
 		position: relative;
-
-		button {
-			position: absolute;
-			left: 19px;
-			top: 16px;
-			z-index: 50;
-			padding: 0; 
-		}
-
-		button:focus {
-			background: none;
-			border: none;
-			outline: none;
-			box-shadow: none; 
-		}
 
 		img {
 			object-fit: cover;
@@ -105,51 +90,28 @@
 			position: relative;
 			z-index: 10;
 			border-radius: 40px;
-			z-index: 5; 
-		}
-	}
-}
-
-#editor .ab-has-avatar {
-	.ab-testimonial-image-wrap {
-		button {
-			top: 0;
-			left: 0;
-			opacity: 1 !important;
-			height: 100%;
-		}
-
-		&:hover {
-			cursor: pointer;
-
-			img {
-				opacity: .7; 	
-			}
-
-			button {
-				opacity: 1; 
-			}
+			z-index: 5;
 		}
 	}
 }
 
 .right-aligned {
 	.ab-testimonial-info {
-		text-align: right; 
+		text-align: right;
 
 		h2 {
-			left: 0; 
+			left: 0;
 		}
 
 		.ab-testimonial-name,
 		.ab-testimonial-title {
 			margin-right: 70px;
-			margin-left: 0; 
+			margin-left: 0;
 		}
 
 		.ab-testimonial-avatar-wrap {
 			left: auto;
-			right: 0; 
+			right: 0;
 		}
 	}
 }


### PR DESCRIPTION
There needs to be a way to remove an image, not just swap it out. This pr adds a button to remove the image, and allow for the user to add another if they wish.

To test: 

1. Switch to master and create a testimonial block with text, name, and image avatar and save.
2. Switch to issue/152 and refresh the page. 
3. The block should pass validation and you should notice a small red X icon that allows you to remove the image. 

Fixes #152.