### PR TITLE
Check for alignment value before outputting

### DIFF
--- a/src/blocks/block-accordion/components/accordion.js
+++ b/src/blocks/block-accordion/components/accordion.js
@@ -23,7 +23,7 @@ export default class Accordion extends Component {
 			<div
 				className={ classnames(
 					this.props.className,
-					'ab-align-' + this.props.attributes.accordionAlignment,
+					this.props.attributes.accordionAlignment ? 'ab-align-' + this.props.attributes.accordionAlignment : undefined,
 					'ab-block-accordion',
 					'ab-font-size-' + this.props.attributes.accordionFontSize,
 				) }

--- a/src/blocks/block-sharing/components/sharing.js
+++ b/src/blocks/block-sharing/components/sharing.js
@@ -27,7 +27,7 @@ export default class ShareLinks extends Component {
 					this.props.attributes.shareButtonShape,
 					this.props.attributes.shareButtonSize,
 					this.props.attributes.shareButtonColor,
-					this.props.attributes.shareAlignment ? this.props.attributes.shareAlignment : 'ab-align-' + undefined,
+					this.props.attributes.shareAlignment ? 'ab-align-' + this.props.attributes.shareAlignment : undefined,
 					'ab-block-sharing'
 				) }
 			>

--- a/src/blocks/block-sharing/components/sharing.js
+++ b/src/blocks/block-sharing/components/sharing.js
@@ -27,7 +27,7 @@ export default class ShareLinks extends Component {
 					this.props.attributes.shareButtonShape,
 					this.props.attributes.shareButtonSize,
 					this.props.attributes.shareButtonColor,
-					'ab-align-' + this.props.attributes.shareAlignment,
+					this.props.attributes.shareAlignment ? this.props.attributes.shareAlignment : 'ab-align-' + undefined,
 					'ab-block-sharing'
 				) }
 			>


### PR DESCRIPTION
Fixes a late bug on #153.

**Summary of change:**
Check for alignment value before outputting on block parent.

**This PR has been:**
- [x] Linted for syntax errors
- [x] Tested against the WordPress coding standards
- [x] Tested with the bundled test suite(s)

**Have the changes in this PR been added to the documentation for this project?**
Does not apply

**How to test:**
Create a sharing and accordion block on the 2.0 tag, publish the block, change your branch to issue/153-fix, and refresh the page. There should not be a `ab-align-undefined` output on the block.