### PR TITLE
Remove Google+ option from Sharing block. #85

### DIFF
--- a/src/blocks/block-sharing/components/edit.js
+++ b/src/blocks/block-sharing/components/edit.js
@@ -59,17 +59,6 @@ export default class Edit extends Component {
 					</li>
 				}
 
-				{ this.props.attributes.google &&
-					<li>
-						<a className='ab-share-google'>
-							<i className="fab fa-google"></i>
-							<span className={ 'ab-social-text' }>
-								{ __( 'Share on Google', 'atomic-blocks' ) }
-							</span>
-						</a>
-					</li>
-				}
-
 				{ this.props.attributes.pinterest &&
 					<li>
 						<a className='ab-share-pinterest'>

--- a/src/blocks/block-sharing/components/inspector.js
+++ b/src/blocks/block-sharing/components/inspector.js
@@ -72,11 +72,6 @@ export default class Inspector extends Component {
 						onChange={ () => this.props.setAttributes({ facebook: ! this.props.attributes.facebook }) }
 					/>
 					<ToggleControl
-						label={ __( 'Google', 'atomic-blocks' ) }
-						checked={ !! this.props.attributes.google }
-						onChange={ () => this.props.setAttributes({ google: ! this.props.attributes.google }) }
-					/>
-					<ToggleControl
 						label={ __( 'Pinterest', 'atomic-blocks' ) }
 						checked={ !! this.props.attributes.pinterest }
 						onChange={ () => this.props.setAttributes({ pinterest: ! this.props.attributes.pinterest }) }

--- a/src/blocks/block-sharing/index.php
+++ b/src/blocks/block-sharing/index.php
@@ -28,10 +28,6 @@ function atomic_blocks_register_sharing() {
 					'type'    => 'boolean',
 					'default' => true,
 				),
-				'google'           => array(
-					'type'    => 'boolean',
-					'default' => true,
-				),
 				'linkedin'         => array(
 					'type'    => 'boolean',
 					'default' => false,
@@ -118,8 +114,6 @@ function atomic_blocks_render_sharing( $attributes ) {
 
 	$facebook_url = 'https://www.facebook.com/sharer/sharer.php?u=' . get_the_permalink() . '&title=' . get_the_title() . '';
 
-	$google_url = 'https://plus.google.com/share?url=' . get_the_permalink() . '';
-
 	$linkedin_url = 'https://www.linkedin.com/shareArticle?mini=true&url=' . get_the_permalink() . '&title=' . get_the_title() . '';
 
 	$pinterest_url = 'https://pinterest.com/pin/create/button/?&url=' . get_the_permalink() . '&description=' . get_the_title() . '&media=' . esc_url( $thumbnail ) . '';
@@ -171,28 +165,6 @@ function atomic_blocks_render_sharing( $attributes ) {
 			</li>',
 			$href_format,
 			esc_html__( 'Share on Facebook', 'atomic-blocks' )
-		);
-	}
-
-	if ( isset( $attributes['google'] ) && $attributes['google'] ) {
-
-		$href_format = sprintf( 'href="javascript:void(0)" onClick="javascript:atomicBlocksShare(\'%1$s\', \'%2$s\', \'600\', \'600\')"', esc_url( $google_url ), esc_html__( 'Share on Google', 'atomic-blocks' ) );
-
-		if ( $is_amp_endpoint ) {
-			$href_format = sprintf( 'href="%1$s"', esc_url( $google_url ) );
-		}
-
-		$share_url .= sprintf(
-			'<li>
-				<a
-					%1$s
-					class="ab-share-google"
-					title="%2$s">
-					<i class="fab fa-google"></i> <span class="ab-social-text">%2$s</span>
-				</a>
-			</li>',
-			$href_format,
-			esc_html__( 'Share on Google', 'atomic-blocks' )
 		);
 	}
 


### PR DESCRIPTION
Google shut down Google+, so we can remove this option.

**This PR has been:**
- [X] Linted for syntax errors
- [X] Tested against the WordPress coding standards
- [X] Tested with the bundled test suite(s)

**Fixes:** #85 

**Suggested Changelog Entry:**
Remove Google+ option from Sharing block.

