### PR TITLE
Remove default font value

### DIFF
--- a/src/blocks/block-accordion/components/accordion.js
+++ b/src/blocks/block-accordion/components/accordion.js
@@ -25,7 +25,7 @@ export default class Accordion extends Component {
 					this.props.className,
 					this.props.attributes.accordionAlignment ? 'ab-align-' + this.props.attributes.accordionAlignment : undefined,
 					'ab-block-accordion',
-					'ab-font-size-' + this.props.attributes.accordionFontSize,
+					this.props.attributes.accordionFontSize ? 'ab-font-size-' + this.props.attributes.accordionFontSize : null,
 				) }
 			>
 				{ this.props.children }

--- a/src/blocks/block-accordion/index.js
+++ b/src/blocks/block-accordion/index.js
@@ -38,7 +38,7 @@ const blockAttributes = {
 	},
 	accordionFontSize: {
 		type: 'number',
-		default: 18
+		default: null
 	},
 	accordionOpen: {
 		type: 'boolean',


### PR DESCRIPTION
By removing the default value, users can clear the font size output and use their theme font sizes instead.

**Summary of change:**
- Set default value on attribute to null
- Added check for font value before outputting class

**This PR has been:**
- [x] Linted for syntax errors
- [x] Tested against the WordPress coding standards
- [x] Tested with the bundled test suite(s)

**Have the changes in this PR been added to the documentation for this project?**
Does not apply

**How to test:**
1. Check out the 2.0 branch
2. Add an accordion block to the page, set a font size, save the page
3. Switch to issue/171 branch
4. Refresh the page, clear the default font value from the slider, and save the page
5. Check to make sure the block doesn't break and that a font class wasn't output on the front end

**Fixes:** #171 