### PR TITLE
Remove overly specific font size styles

### DIFF
--- a/src/blocks/block-accordion/components/inspector.js
+++ b/src/blocks/block-accordion/components/inspector.js
@@ -33,7 +33,7 @@ export default class Inspector extends Component {
 			<InspectorControls key="inspector">
 				<PanelBody>
 					<RangeControl
-						label={ __( 'Font Size', 'atomic-blocks' ) }
+						label={ __( 'Title Font Size', 'atomic-blocks' ) }
 						value={ this.props.attributes.accordionFontSize }
 						onChange={ ( value ) => this.props.setAttributes({ accordionFontSize: value }) }
 						min={ 14 }

--- a/src/blocks/block-accordion/styles/style.scss
+++ b/src/blocks/block-accordion/styles/style.scss
@@ -4,12 +4,12 @@
  */
 
  .ab-block-accordion {
-	 margin-bottom: 1.2em; 
+	 margin-bottom: 1.2em;
 
 	.ab-accordion-title {
 		background: #f2f2f2;
 		padding: 10px 15px;
-		
+
 		p {
 			display: inline;
 		}
@@ -27,4 +27,52 @@
 
 .ab-block-accordion + .ab-block-accordion {
 	margin-top: -.6em;
+}
+
+/* Font size styles */
+@media only screen and (min-width: 600px) {
+
+	.ab-font-size-14 .ab-accordion-title {
+		font-size: 14px;
+	}
+
+	.ab-font-size-15 .ab-accordion-title {
+		font-size: 15px;
+	}
+
+	.ab-font-size-16 .ab-accordion-title {
+		font-size: 16px;
+	}
+
+	.ab-font-size-17 .ab-accordion-title {
+		font-size: 17px;
+	}
+
+	.ab-font-size-18 .ab-accordion-title {
+		font-size: 18px;
+	}
+
+	.ab-font-size-19 .ab-accordion-title {
+		font-size: 19px;
+	}
+
+	.ab-font-size-20 .ab-accordion-title {
+		font-size: 20px;
+	}
+
+	.ab-font-size-21 .ab-accordion-title {
+		font-size: 21px;
+	}
+
+	.ab-font-size-22 .ab-accordion-title {
+		font-size: 22px;
+	}
+
+	.ab-font-size-23 .ab-accordion-title {
+		font-size: 23px;
+	}
+
+	.ab-font-size-24 .ab-accordion-title {
+		font-size: 24px;
+	}
 }

--- a/src/blocks/global-styles/styles/style.scss
+++ b/src/blocks/global-styles/styles/style.scss
@@ -11,7 +11,6 @@
 		&.ab-block-testimonial p,
 		&.ab-block-notice p,
 		&.ab-block-profile p,
-		&.ab-block-accordion p,
 		&.ab-block-cta p {
 			font-size: 14px;
 		}
@@ -22,7 +21,6 @@
 		&.ab-block-testimonial p,
 		&.ab-block-notice p,
 		&.ab-block-profile p,
-		&.ab-block-accordion p,
 		&.ab-block-cta p {
 			font-size: 15px;
 		}
@@ -33,7 +31,6 @@
 		&.ab-block-testimonial p,
 		&.ab-block-notice p,
 		&.ab-block-profile p,
-		&.ab-block-accordion p,
 		&.ab-block-cta p {
 			font-size: 16px;
 		}
@@ -44,7 +41,6 @@
 		&.ab-block-testimonial p,
 		&.ab-block-notice p,
 		&.ab-block-profile p,
-		&.ab-block-accordion p,
 		&.ab-block-cta p {
 			font-size: 17px;
 		}
@@ -55,7 +51,6 @@
 		&.ab-block-testimonial p,
 		&.ab-block-notice p,
 		&.ab-block-profile p,
-		&.ab-block-accordion p,
 		&.ab-block-cta p {
 			font-size: 18px;
 		}
@@ -66,7 +61,6 @@
 		&.ab-block-testimonial p,
 		&.ab-block-notice p,
 		&.ab-block-profile p,
-		&.ab-block-accordion p,
 		&.ab-block-cta p {
 			font-size: 19px;
 		}
@@ -77,7 +71,6 @@
 		&.ab-block-testimonial p,
 		&.ab-block-notice p,
 		&.ab-block-profile p,
-		&.ab-block-accordion p,
 		&.ab-block-cta p {
 			font-size: 20px;
 		}
@@ -88,7 +81,6 @@
 		&.ab-block-testimonial p,
 		&.ab-block-notice p,
 		&.ab-block-profile p,
-		&.ab-block-accordion p,
 		&.ab-block-cta p {
 			font-size: 21px;
 		}
@@ -99,7 +91,6 @@
 		&.ab-block-testimonial p,
 		&.ab-block-notice p,
 		&.ab-block-profile p,
-		&.ab-block-accordion p,
 		&.ab-block-cta p {
 			font-size: 22px;
 		}
@@ -110,7 +101,6 @@
 		&.ab-block-testimonial p,
 		&.ab-block-notice p,
 		&.ab-block-profile p,
-		&.ab-block-accordion p,
 		&.ab-block-cta p {
 			font-size: 23px;
 		}
@@ -121,7 +111,6 @@
 		&.ab-block-testimonial p,
 		&.ab-block-notice p,
 		&.ab-block-profile p,
-		&.ab-block-accordion p,
 		&.ab-block-cta p {
 			font-size: 24px;
 		}


### PR DESCRIPTION
**Summary of change:**
- Make font size adjustment specific to accordion title so child blocks can control their own font.
- Move the accordion font size selector to the accordion stylesheet.

**This PR has been:**
- [x] Linted for syntax errors
- [x] Tested against the WordPress coding standards
- [x] Tested with the bundled test suite(s)

**How to test:**
Change the font size adjustment on the accordion and ensure child blocks don't get these font styles applied.

**Fixes:** #177 