### PR TITLE
Add double opt-in option to newsletter block. #143

### DIFF
--- a/dist/assets/js/newsletter-block-functions.js
+++ b/dist/assets/js/newsletter-block-functions.js
@@ -27,6 +27,8 @@ var AtomicBlocksNewsletterSubmission = {
 
 			var ampEndpoint = button.parent().find( '[name=\'ab-newsletter-amp-endpoint-request\']' ).val();
 
+			var doubleOptIn = button.parent().find( '[name=\'ab-newsletter-double-opt-in\']' ).val();
+
 			event.preventDefault();
 
 			wp.a11y.speak( atomic_blocks_newsletter_vars.l10n.a11y.submission_processing );
@@ -54,7 +56,8 @@ var AtomicBlocksNewsletterSubmission = {
 					'ab-newsletter-mailing-list': list,
 					'ab-newsletter-form-nonce': nonce,
 					'ab-newsletter-success-message': successMessage,
-					'ab-newsletter-amp-endpoint-request': ampEndpoint
+					'ab-newsletter-amp-endpoint-request': ampEndpoint,
+					'ab-newsletter-double-opt-in': doubleOptIn
 				},
 				type: 'post',
 				url: atomic_blocks_newsletter_vars.ajaxurl,

--- a/includes/classes/class-mailchimp.php
+++ b/includes/classes/class-mailchimp.php
@@ -67,6 +67,12 @@ final class Mailchimp implements Provider_Interface {
 		$email   = sanitize_email( trim( $email ) );
 		$list_id = ! empty( $args['list_id'] ) ? sanitize_text_field( $args['list_id'] ) : false;
 
+		$status         = 'subscribed';
+		$valid_statuses = [ 'subscribed', 'pending' ];
+		if ( ! empty( $args['status'] ) && in_array( $args['status'], $valid_statuses, true ) ) {
+			$status = $args['status'];
+		}
+
 		if ( empty( $email ) || ! is_email( $email ) ) {
 			throw new Mailchimp_API_Error_Exception(
 				esc_html__( 'An invalid email address was provided.', 'atomic-blocks' )
@@ -89,7 +95,7 @@ final class Mailchimp implements Provider_Interface {
 			$request_method,
 			[
 				'email_address' => $email,
-				'status'        => 'subscribed',
+				'status'        => $status,
 			]
 		);
 

--- a/src/blocks/block-newsletter/components/inspector.js
+++ b/src/blocks/block-newsletter/components/inspector.js
@@ -19,6 +19,7 @@ const {
 const { PanelBody,
 	SelectControl,
 	TextControl,
+	FormToggle,
 	withFallbackStyles
 } = wp.components;
 
@@ -43,6 +44,12 @@ const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
 });
 
 class Inspector extends Component {
+
+	doubleOptInChange( event ) {
+		if ( this.props.doubleOptIn ) {
+			this.props.doubleOptIn( event.target.checked );
+		}
+	}
 
 	render() {
 
@@ -102,6 +109,25 @@ class Inspector extends Component {
 						value={ attributes.successMessage }
 						onChange={ ( value ) => setAttributes({ successMessage: value }) }
 					/>
+
+					<div className="ab-newsletter-double-opt-in-setting-wrapper">
+						<FormToggle
+							id={ 'double-opt-in-toggle-' + this.props.instanceId }
+							className="ab-newsletter-double-opt-in-toggle"
+							checked={ attributes.doubleOptIn }
+							onChange={ ( event ) => setAttributes({ doubleOptIn: event.target.checked }) }
+						/>
+						<label
+							className="ab-newsletter-double-opt-in-setting-label"
+							htmlFor={ 'double-opt-in-toggle-' + this.props.instanceId }
+						>
+							{ __( 'Enable Double Opt-In', 'atomic-blocks' ) }
+						</label>
+						<p className="description">
+							{ __( 'Send contacts an opt-in confirmation email when they subscribe to your list.', 'atomic-blocks' ) }
+						</p>
+					</div>
+
 				</PanelBody>
 
 				<PanelBody

--- a/src/blocks/block-newsletter/index.php
+++ b/src/blocks/block-newsletter/index.php
@@ -135,6 +135,7 @@ function atomic_blocks_render_newsletter_block( $attributes ) {
 				<input type="hidden" name="ab-newsletter-mailing-list-provider" value="' . esc_attr( $attributes['mailingListProvider'] ) . '" />
 				<input type="hidden" name="ab-newsletter-mailing-list" value="' . esc_attr( $attributes['mailingList'] ) . '" />
 				<input type="hidden" name="ab-newsletter-success-message" value="' . esc_attr( $attributes['successMessage'] ) . '" />
+				<input type="hidden" name="ab-newsletter-double-opt-in" value="' . esc_attr( $attributes['doubleOptIn'] ) . '" />
 				<input type="hidden" name="ab-newsletter-amp-endpoint-request" value="' . $amp_endpoint . '" />
 				<input type="hidden" name="ab-newsletter-form-nonce" value="' . wp_create_nonce( 'ab-newsletter-form-nonce' ) . '" />
 			</form>
@@ -229,6 +230,10 @@ function atomic_blocks_newsletter_block_attributes() {
 		'instanceId'                  => [
 			'type'    => 'number',
 			'default' => 1,
+		],
+		'doubleOptIn'                 => [
+			'type'    => 'boolean',
+			'default' => false,
 		],
 	];
 }

--- a/src/blocks/block-newsletter/styles/editor.scss
+++ b/src/blocks/block-newsletter/styles/editor.scss
@@ -9,13 +9,6 @@
 	}
 }
 
-.ab-nested-panel {
-	&.components-panel__body h2.components-panel__body-title > .components-panel__body-toggle {
-		padding-top: 15px;
-		padding-bottom: 15px;
-	}
-}
-
 .ab-form-styles {
 	label {
 		margin-bottom: 8px;
@@ -31,4 +24,15 @@
 		padding: 15px;
 		font-size: 16px;
 	}
+}
+
+.ab-newsletter-double-opt-in-setting-wrapper {
+	margin-bottom: 24px;
+
+	.description {
+		margin-bottom: 5px;
+	}
+}
+.ab-newsletter-double-opt-in-toggle {
+	margin-right: 5px;
 }


### PR DESCRIPTION
**Summary of change:**
Adds an option to the newsletter block called `Enable Double Opt-In`, which will add the member to the list in a pending status and trigger a confirmation email from Mailchimp.

**This PR has been:**
- [X] Linted for syntax errors
- [X] Tested against the WordPress coding standards
- [X] Tested with the bundled test suite(s)

**How to test:**
- Check out `issue/143`
- Run `npm run build-assets`
- Add block to page
- Select desired list
- Enable Double Opt-In option
- Publish page
- Subscribe to list
- Confirm that you get a double opt-in confirmation email from Mailchimp
- Disable Double Opt-In option
- Save page
- Subscribe to list
- Confirm that you do not get a double opt-in email and that your email was automatically subscribed to the selected list.

**Fixes:** #143 

**Suggested Changelog Entry:**
Added Double Opt-In support to newsletter block.
