### PR TITLE
Improve image hover styles

### DIFF
--- a/src/blocks/block-author-profile/styles/editor.scss
+++ b/src/blocks/block-author-profile/styles/editor.scss
@@ -36,3 +36,22 @@
 	top: 5px;
 	right: 5px;
 }
+
+#editor .ab-has-avatar {
+
+	.ab-profile-image-square {
+		button {
+			top: 0;
+			left: 0;
+			height: 100%;
+		}
+
+		.ab-change-image {
+			transition: .2s ease;
+
+			&:hover {
+				opacity: .7;
+			}
+		}
+	}
+}

--- a/src/blocks/block-author-profile/styles/style.scss
+++ b/src/blocks/block-author-profile/styles/style.scss
@@ -187,24 +187,3 @@
 		border-radius: 500px;
 	}
 }
-
-#editor .ab-has-avatar {
-
-	.ab-profile-image-square {
-		&:hover {
-			cursor: pointer;
-
-			img {
-				opacity: .7 !important;
-			}
-		}
-
-		button {
-			top: 0;
-			left: 0;
-			opacity: 1 !important;
-			height: 100%;
-		}
-	}
-
-}

--- a/src/blocks/global-styles/styles/editor.scss
+++ b/src/blocks/global-styles/styles/editor.scss
@@ -5,8 +5,18 @@
 		padding: 0;
 		top: 0;
 		left: 0;
-		opacity: 1 !important;
+		opacity: 1;
 		height: 100%;
+
+		img {
+			transition: .2s ease;
+		}
+
+		&:hover {
+			img {
+				opacity: .7
+			}
+		}
 	}
 
 	.ab-change-image:focus {
@@ -14,18 +24,6 @@
 		border: none;
 		outline: none;
 		box-shadow: none;
-	}
-
-	&:hover {
-		cursor: pointer;
-
-		img {
-			opacity: .7;
-		}
-
-		.ab-change-image {
-			opacity: 1;
-		}
 	}
 
 	.ab-add-image {


### PR DESCRIPTION
Fixes #184.

**Summary of change:**
Make image hover CSS more specific and relocate to better spot.

**This PR has been:**
- [x] Linted for syntax errors
- [x] Tested against the WordPress coding standards
- [x] Tested with the bundled test suite(s)

**How to test:**
Add a testimonial and author profile block with an avatar on each. The image opacity should fade slightly on hover. 

**See:** #xxx

**Fixes:** #184 

**Suggested Changelog Entry:**
Improve image hover styles on author profile and testimonial block.