### PR TITLE
Refine sibling selector for one column

### DIFF
--- a/src/blocks/block-column-inner/styles/editor.scss
+++ b/src/blocks/block-column-inner/styles/editor.scss
@@ -109,7 +109,7 @@
 
 /* One column grid. */
 
-.ab-layout-columns-1 > .editor-block-list__layout {
+.ab-layout-columns-1 > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
 	grid-template-columns: 1fr;
 	grid-template-areas: "col1";
 }


### PR DESCRIPTION
This needed a few additional selectors to take into account other use cases. Fixes #188.