### PR TITLE
Fix display block alignment

### DIFF
--- a/src/blocks/block-column-inner/styles/editor.scss
+++ b/src/blocks/block-column-inner/styles/editor.scss
@@ -263,5 +263,4 @@
 .ab-block-layout-column .wp-block-image,
 .ab-block-layout-column .wp-block-image .components-resizable-box__container {
 	max-width: 100% !important;
-	display: block;
 }


### PR DESCRIPTION
**Summary of change:**
This `display: block` is causing issues with core image alignment. We can safely remove this. 

**This PR has been:**
- [x] Linted for syntax errors
- [x] Tested against the WordPress coding standards
- [x] Tested with the bundled test suite(s)

**How to test:**
Add an image to a post, you should be able to left, center, and right align the image.

**Fixes:** #193 