### PR TITLE
Add WordPress profile area

### DIFF
--- a/src/blocks/block-author-profile/components/inspector.js
+++ b/src/blocks/block-author-profile/components/inspector.js
@@ -30,7 +30,7 @@ export default class Inspector extends Component {
 	render() {
 
 		/* Setup the attributes */
-		const { profileName, profileTitle, profileContent, profileAlignment, profileImgURL, profileImgID, profileFontSize, profileBackgroundColor, profileTextColor, profileLinkColor, twitter, facebook, instagram, pinterest, google, youtube, github, linkedin, email, website, profileAvatarShape  } = this.props.attributes;
+		const { profileName, profileTitle, profileContent, profileAlignment, profileImgURL, profileImgID, profileFontSize, profileBackgroundColor, profileTextColor, profileLinkColor, twitter, facebook, instagram, pinterest, google, youtube, github, linkedin, wordpress, email, website, profileAvatarShape  } = this.props.attributes;
 		const { setAttributes } = this.props;
 
 		/* Avatar shape options */
@@ -155,6 +155,13 @@ export default class Inspector extends Component {
 					type="url"
 					value={ linkedin }
 					onChange={ ( value ) => this.props.setAttributes({ linkedin: value }) }
+				/>
+
+				<TextControl
+					label={ __( 'WordPress URL', 'atomic-blocks' ) }
+					type="url"
+					value={ wordpress }
+					onChange={ ( value ) => this.props.setAttributes({ wordpress: value }) }
 				/>
 
 				<TextControl

--- a/src/blocks/block-author-profile/components/inspector.js
+++ b/src/blocks/block-author-profile/components/inspector.js
@@ -158,7 +158,7 @@ export default class Inspector extends Component {
 				/>
 
 				<TextControl
-					label={ __( 'WordPress URL', 'atomic-blocks' ) }
+					label={ __( 'WordPress Profile URL', 'atomic-blocks' ) }
 					type="url"
 					value={ wordpress }
 					onChange={ ( value ) => this.props.setAttributes({ wordpress: value }) }

--- a/src/blocks/block-author-profile/components/social.js
+++ b/src/blocks/block-author-profile/components/social.js
@@ -70,6 +70,12 @@ export default class SocialIcons extends Component {
 					</li>
 				) }
 
+				{ this.props.attributes.wordpress && !! this.props.attributes.wordpress.length && (
+					<li>
+						<a href={ this.props.attributes.wordpress } target="_blank" rel="noopener noreferrer">{ __( 'WordPress', 'atomic-blocks' ) } <i style={ { backgroundColor: this.props.attributes.profileLinkColor } } className="fab fa-wordpress-simple"></i></a>
+					</li>
+				) }
+
 				{ this.props.attributes.email && !! this.props.attributes.email.length && (
 					<li>
 						<a href={ this.props.attributes.email } target="_blank" rel="noopener noreferrer">{ __( 'Email', 'atomic-blocks' ) } <i style={ { backgroundColor: this.props.attributes.profileLinkColor } } className="far fa-envelope"></i></a>

--- a/src/blocks/block-author-profile/index.js
+++ b/src/blocks/block-author-profile/index.js
@@ -99,6 +99,9 @@ const blockAttributes = {
 	email: {
 		type: 'url'
 	},
+	wordpress: {
+		type: 'url'
+	},
 	website: {
 		type: 'url'
 	}


### PR DESCRIPTION
**Summary of change:**
This PR brings the WordPress profile into AB `block-author-profile`.

**This PR has been:**
- [x] Linted for syntax errors
- [x] Tested against the WordPress coding standards
- [x] Tested with the bundled test suite(s)

**How to test:**
- Download the branch;
- Add a new `block-author-profile`;
- Add any value to `WordPress URL`;
- The WordPress icon as a link should show.

**Closes** #201

**Suggested Changelog Entry:**
* Add WordPress Profile URL section on `block-author-profile`
