### PR TITLE
Remove CSS Grid autoprefixer support

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -52,8 +52,7 @@ const extractConfig = {
 							'Firefox ESR',
 							'not ie < 9' // React doesn't support IE8 anyway
 						],
-						flexbox: 'no-2009',
-						grid: true
+						flexbox: 'no-2009'
 					})
 				]
 			}

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -56,8 +56,7 @@ const extractConfig = {
 							'Firefox ESR',
 							'not ie < 9' // React doesn't support IE8 anyway
 						],
-						flexbox: 'no-2009',
-						grid: true
+						flexbox: 'no-2009'
 					})
 				]
 			}


### PR DESCRIPTION
**Summary of change:**
Remove CSS Grid autoprefixer support in favor of our own styles.

**How to test:**
Run a build and ensure the autoprefixer isn't outputting MS specific styles.

<!-- If this PR fully resolves an existing issue, link it here. -->
**Fixes:** #204 