### PR TITLE
Fix editor crash under WP 5.0

### DIFF
--- a/src/blocks/block-column-inner/index.js
+++ b/src/blocks/block-column-inner/index.js
@@ -115,14 +115,14 @@ registerBlockType( 'atomic-blocks/ab-column', {
 
 /* Add the vertical column alignment class to the block wrapper. */
 const withClientIdClassName = wp.compose.createHigherOrderComponent( ( BlockListBlock ) => {
-    return ( props ) => {
+	return ( props ) => {
 		const blockName = props.block.name;
 
-		if ( props.attributes.columnVerticalAlignment && 'atomic-blocks/ab-column' === blockName ) {
-            return <BlockListBlock { ...props } className={ 'ab-is-vertically-aligned-' + props.attributes.columnVerticalAlignment } />;
-        } else {
-            return <BlockListBlock { ...props } />;
-        }
+		if ( 'atomic-blocks/ab-column' === blockName && props.block.attributes.columnVerticalAlignment ) {
+			return <BlockListBlock { ...props } className={ 'ab-is-vertically-aligned-' + props.block.attributes.columnVerticalAlignment } />;
+		} else {
+			return <BlockListBlock { ...props } />;
+		}
 	};
 }, 'withClientIdClassName' );
 


### PR DESCRIPTION
Copied from https://github.com/studiopress/atomic-blocks/pull/203, originally opened by @nickcernis.

**Summary of change:**
Fixes https://github.com/studiopress/atomic-blocks/issues/202 for WP 5.0 (without affecting WP 5.2).

**Have the changes in this PR been added to the documentation for this project?**
Not required.

**How to test:**
1. `git checkout fix/column-vertical-alignment`
2. `npm ci` if deps are not yet installed.
3. `npm run build`
4. Under WP 5.0: visit `/wp-admin/post-new.php?post_type=page` with Atomic Blocks active.
5. Click in the main editor section. You should no longer see the block editor crash.
6. Create an AB Advanced Columns block and set the vertical alignment.
7. Confirm the vertical alignment class is added to the columns block on the front and back end (e.g. `ab-is-vertically-aligned-top`) when changing vertical alignment.

Repeat the above test under WP 5.2.2 to confirm all is good there and the Atomic Blocks vertical align class is still applied correctly.

**Suggested Changelog Entry:**
Prevent the block editor crashing under WordPress 5.0.

**Alternatives:**
The minimum supported version of WP could be raised instead of applying this fix. I haven't yet tested every version between 5.0 and 5.2 to determine in what version `props.attributes` is no longer undefined.