### PR TITLE
Remove jQuery from dependency array on dismiss.js. #210

### DIFF
--- a/dist/init.php
+++ b/dist/init.php
@@ -104,7 +104,7 @@ function atomic_blocks_frontend_assets() {
 	wp_enqueue_script(
 		'atomic-blocks-dismiss-js',
 		plugins_url( '/dist/assets/js/dismiss.js', dirname( __FILE__ ) ),
-		array( 'jquery' ),
+		array(),
 		filemtime( plugin_dir_path( __FILE__ ) . '/assets/js/dismiss.js' ),
 		true
 	);


### PR DESCRIPTION
**Summary of change:**
Removes the jQuery dependency loading by dismiss.js, since that code no longer requires jQuery.

**How to test:**
- In the latest release or master version of AB, note that jQuery is loaded on the front end.
- Check out `issue/210`
- Unless the theme or another plugin requires jQuery, it should no longer be loaded on the front end.
- Verify that Notice dismissals work as expected. Three things:
  - Dismissible notices are dismissed when you click the X to dismiss them
  - Dismissible notices do not show again when you refresh the page after dismissing them
  - Non-dismissible notices still show as they did before

**Fixes:** #210 

**Suggested Changelog Entry:**
Removed unnecessary jQuery dependency in Notice block.