### PR TITLE
Remove wildcard selector for column styles

### DIFF
--- a/src/blocks/block-column-inner/styles/style.scss
+++ b/src/blocks/block-column-inner/styles/style.scss
@@ -41,7 +41,8 @@
 }
 
 .ab-block-layout-column-inner,
-.ab-layout-column-wrap > .ab-block-layout-column-inner {
+.ab-layout-column-wrap > .ab-block-layout-column-inner,
+.ab-has-background-dim > * {
 	position: relative;
 	z-index: 1;
 }

--- a/src/blocks/block-column-inner/styles/style.scss
+++ b/src/blocks/block-column-inner/styles/style.scss
@@ -41,7 +41,7 @@
 }
 
 .ab-block-layout-column-inner,
-.ab-layout-column-wrap .ab-block-layout-column-inner * {
+.ab-layout-column-wrap > .ab-block-layout-column-inner {
 	position: relative;
 	z-index: 1;
 }

--- a/src/utils/components/background-image/classes.js
+++ b/src/utils/components/background-image/classes.js
@@ -5,7 +5,7 @@ import { dimRatioToClass } from './shared';
  */
 function BackgroundImageClasses( attributes ) {
 	return [
-		100 !== attributes.backgroundDimRatio ? 'ab-has-background-dim' : null,
+		attributes.backgroundDimRatio && 100 !== attributes.backgroundDimRatio ? 'ab-has-background-dim' : null,
 		dimRatioToClass( attributes.backgroundDimRatio ),
 		attributes.backgroundImgURL && attributes.backgroundSize && 'no-repeat' === attributes.backgroundRepeat ? 'ab-background-' + attributes.backgroundSize : null,
 		attributes.backgroundImgURL && attributes.backgroundRepeat ? 'ab-background-' + attributes.backgroundRepeat : null,


### PR DESCRIPTION
This PR fixes #212, removing a wildcard selector that applies relative positioning to all child elements. 