### PR TITLE
Fix background image opacity on column block

### DIFF
--- a/src/utils/components/background-image/classes.js
+++ b/src/utils/components/background-image/classes.js
@@ -5,7 +5,7 @@ import { dimRatioToClass } from './shared';
  */
 function BackgroundImageClasses( attributes ) {
 	return [
-		attributes.backgroundDimRatio && 100 !== attributes.backgroundDimRatio ? 'ab-has-background-dim' : null,
+		attributes.backgroundDimRatio !== undefined && 100 !== attributes.backgroundDimRatio ? 'ab-has-background-dim' : null,
 		dimRatioToClass( attributes.backgroundDimRatio ),
 		attributes.backgroundImgURL && attributes.backgroundSize && 'no-repeat' === attributes.backgroundRepeat ? 'ab-background-' + attributes.backgroundSize : null,
 		attributes.backgroundImgURL && attributes.backgroundRepeat ? 'ab-background-' + attributes.backgroundRepeat : null,


### PR DESCRIPTION
Small fix to the background image opacity slider. 

To test, add the column block, set a background image, take the slider down to zero. The background image should disappear. 

Fixes #218 