### PR TITLE
Add one column support to the Post Grid block

### DIFF
--- a/src/blocks/block-post-grid/components/inspector.js
+++ b/src/blocks/block-post-grid/components/inspector.js
@@ -191,7 +191,7 @@ export default class Inspector extends Component {
 							label={ __( 'Columns', 'atomic-blocks' ) }
 							value={ attributes.columns }
 							onChange={ ( value ) => setAttributes({ columns: value }) }
-							min={ 2 }
+							min={ 1 }
 							max={ ! hasPosts ? MAX_POSTS_COLUMNS : Math.min( MAX_POSTS_COLUMNS, latestPosts.length ) }
 						/>
 					}

--- a/src/blocks/block-post-grid/index.php
+++ b/src/blocks/block-post-grid/index.php
@@ -254,7 +254,7 @@ function atomic_blocks_render_block_core_latest_posts( $attributes ) {
 				$section_title_tag = 'h2';
 			}
 
-			$section_title = '<' . esc_attr( $section_title_tag ) . '>' . esc_html( $attributes['sectionTitle'] ) . '</' . esc_attr( $section_title_tag ) . '>';
+			$section_title = '<' . esc_attr( $section_title_tag ) . ' class="ab-post-grid-section-title">' . esc_html( $attributes['sectionTitle'] ) . '</' . esc_attr( $section_title_tag ) . '>';
 		} else {
 			$section_title = null;
 		}

--- a/src/blocks/block-post-grid/styles/style.scss
+++ b/src/blocks/block-post-grid/styles/style.scss
@@ -30,6 +30,16 @@
 		}
 	}
 
+	.is-grid.columns-1 {
+		grid-template-columns: 1fr;
+
+		@media all and (-ms-high-contrast:none) {
+			article {
+				width: 100%;
+			}
+		}
+	}
+
 	.is-grid.columns-2 {
 		grid-template-columns: 1fr 1fr;
 


### PR DESCRIPTION
- Change the column slider minimum to 1
- Add styles for 1 column layout

**How to test:**
- Check out the branch
- Run `npm run start` to rebuild the assets
- Add the Post Grid to the page and change the column slider to 1

**Fixes:** #223 

**Suggested Changelog Entry:**
Add one column support to the Post Grid block.