### PR TITLE
Set modal state in componentDidMount. #226

### DIFF
--- a/src/blocks/block-layout/components/layout/layout-modal.js
+++ b/src/blocks/block-layout/components/layout/layout-modal.js
@@ -24,11 +24,13 @@ class LayoutModal extends Component {
 		super( ...arguments );
 
 		this.state = {
-			modalOpen: true,
 			currentTab: 'ab-layout-tab-sections'
 		};
 	}
 
+	componentDidMount() {
+		this.setState({ modalOpen: true });
+	}
 	render() {
 		return (
 			<Fragment key={ 'layout-modal-fragment-' + this.props.clientId }>


### PR DESCRIPTION
**Summary of change:**
Sets the `modalOpen` state value in `componentDidMount`, which fixes the issue described in #226.

**How to test:**
- Using latest version of AB, download latest version of Gutenberg plugin.
- Note that the modal does not open when layouts are added to the page.
- Check out this branch, run `npm run start` to build the assets.
- Repeat test above and verify that modal opens.
- Verify this still works as expected without Gutenberg plugin active.

<!-- If this PR fully resolves an existing issue, link it here. -->
**Fixes:** #226.
