### PR TITLE
Increase number of mailing lists retrieved. #224

### DIFF
--- a/includes/classes/class-mailchimp.php
+++ b/includes/classes/class-mailchimp.php
@@ -131,7 +131,7 @@ final class Mailchimp implements Provider_Interface {
 		$lists = get_transient( 'atomic_blocks_mailchimp_lists' );
 
 		if ( empty( $lists ) ) {
-			$response = (array) $this->mailchimp->get( 'lists' );
+			$response = (array) $this->mailchimp->get( 'lists', [ 'count' => 200 ] );
 			if ( ! empty( $response['lists'] ) ) {
 				$lists = $response['lists'];
 			}


### PR DESCRIPTION
**Summary of change:**
Increasing number of lists retrieved from MailChimp API to 200, up from the default of 10.

**How to test:**
Note: Requires a MailChimp account with more than 10 lists.

- Check out the `issue/224` branch here.
- Using the [Transients Manager plugin](https://wordpress.org/plugins/transients-manager/), clear the `atomic_blocks_mailchimp_lists` transient on your site.
- Add the newsletter block to a new page.
- Ensure that more than 10 lists are returned in the dropdown in the sidebar.

<!-- If this PR fully resolves an existing issue, link it here. -->
**Fixes:** #224.

**Suggested Changelog Entry:**
Newsletter block: Fixes mailing list dropdown issue on MailChimp accounts with more than 10 mailing lists.
