### PR TITLE
Fix Grid styles in IE11

### DIFF
--- a/src/blocks/block-column-inner/styles/style.scss
+++ b/src/blocks/block-column-inner/styles/style.scss
@@ -12,6 +12,7 @@
 }
 
 .ab-layout-column-wrap {
+	display: -ms-grid;
 	display: grid;
     grid-template-rows: 1fr;
 	grid-gap: 0 2em;


### PR DESCRIPTION
**Summary of change:**
Fix Grid styles in IE11 by adding a `-ms` fallback prefix.

**How to test:**
Good luck! 

<!-- If this PR is in reference to an existing issue, link it here. -->
**See:** #241 

<!-- If this PR fully resolves an existing issue, link it here. -->
**Fixes:** #241 

**Suggested Changelog Entry:**
Improve Grid styles in IE11.