### PR TITLE
Add support for EditorsKit navigator toolbar

### DIFF
--- a/src/blocks/block-column-inner/index.js
+++ b/src/blocks/block-column-inner/index.js
@@ -102,6 +102,12 @@ registerBlockType( 'atomic-blocks/ab-column', {
 		}
 	},
 
+	/* Add block supports */
+	supports: {
+		// Add EditorsKit block navigator toolbar
+		editorsKitBlockNavigator: true,
+	},
+
 	/* Render the block in the editor. */
 	edit: props => {
 		return <Edit { ...props } />;

--- a/src/blocks/block-column/index.js
+++ b/src/blocks/block-column/index.js
@@ -116,6 +116,12 @@ registerBlockType( 'atomic-blocks/ab-columns', {
 		}
 	},
 
+	/* Add block supports */
+	supports:{
+		// Add EditorsKit block navigator toolbar
+		editorsKitBlockNavigator : true,
+	},
+
 	/* Add alignment to block wrapper. */
 	getEditWrapperProps({ align }) {
 		if ( 'left' === align || 'right' === align || 'full' === align || 'wide' === align ) {

--- a/src/blocks/block-container/index.js
+++ b/src/blocks/block-container/index.js
@@ -198,6 +198,12 @@ registerBlockType( 'atomic-blocks/ab-container', {
 		}
 	},
 
+	/* Add block supports */
+	supports: {
+		// Add EditorsKit block navigator toolbar
+		editorsKitBlockNavigator: true,
+	},
+
 	// Render the block components
 	edit: ABContainerBlock,
 


### PR DESCRIPTION
Hi,

I've just recently added Block Navigation toolbar on my [EditorsKit](https://wordpress.org/plugins/block-options/) plugin. I think this will be of great help on user navigation when both plugins are activated. The toolbar will only be shown on blocks with multiple inner blocks capability. 

- [ ] Columns
- [ ] Container

Here's how it works :

![Screen Capture on 2019-09-21 at 21-49-34](https://user-images.githubusercontent.com/3365507/65402399-ae785a00-de00-11e9-9b3f-e9f98caff495.gif)

Let me know your thoughts.

Thanks,
Jeffrey