### PR TITLE
Add support for additional layouts to layout library

### DIFF
--- a/includes/layout/layout-endpoints.php
+++ b/includes/layout/layout-endpoints.php
@@ -53,9 +53,10 @@ function register_layout_endpoints() {
 		[
 			'methods'             => WP_REST_Server::READABLE,
 			'callback'            => function () {
-				$layouts  = atomic_blocks_get_layouts();
-				$sections = atomic_blocks_get_sections();
-				return new WP_REST_Response( array_merge( $layouts, $sections ) );
+				$layouts            = atomic_blocks_get_layouts();
+				$sections           = atomic_blocks_get_sections();
+				$additional_layouts = apply_filters( 'atomic_blocks_additional_layout_components', [] );
+				return new WP_REST_Response( array_merge( $layouts, $sections, $additional_layouts ) );
 			},
 			'permission_callback' => function () {
 				return current_user_can( 'edit_posts' );

--- a/src/blocks/block-layout/components/edit.js
+++ b/src/blocks/block-layout/components/edit.js
@@ -6,6 +6,7 @@
  * Import dependencies.
  */
 import LayoutModal from './layout/layout-modal';
+import { LayoutsContext } from './layouts-provider';
 
 /**
  * WordPress dependencies.
@@ -49,7 +50,13 @@ export default class Edit extends Component {
 					className={ 'ab-layout-selector-placeholder' }
 					icon="layout"
 				>
-					<LayoutModal clientId={ clientId } />
+					<LayoutsContext.Consumer
+						key={ 'layouts-context-provider-' + this.props.clientId }
+					>
+						{ ( context ) => (
+							<LayoutModal clientId={ clientId } context={ context } />
+						) }
+					</LayoutsContext.Consumer>
 				</Placeholder>
 			</Fragment>
 		];

--- a/src/blocks/block-layout/components/layout/layout-library-item-card.js
+++ b/src/blocks/block-layout/components/layout/layout-library-item-card.js
@@ -1,0 +1,80 @@
+/**
+ * Layout Library Card Item.
+ */
+
+ /**
+ * Dependencies.
+ */
+import classnames from 'classnames';
+import LazyLoad from 'react-lazy-load';
+
+/**
+ * WordPress dependencies.
+ */
+const { __ } = wp.i18n;
+const {
+	Component,
+	Fragment
+} = wp.element;
+const {
+	Button,
+	Dashicon,
+	Tooltip
+} = wp.components;
+
+export default class LayoutLibraryItemCard extends Component {
+	constructor() {
+		super( ...arguments );
+	}
+
+	render() {
+		return (
+			<Fragment>
+				<div key={ 'ab-layout-design-' + this.props.itemKey } className="ab-layout-design">
+					<div className="ab-layout-design-inside">
+						<div className="ab-layout-design-item">
+							<Button
+								key={ this.props.itemKey }
+								className="ab-layout-insert-button"
+								isSmall
+								onClick={ () => {
+									this.props.import( this.props.content );
+								} }
+							>
+								<LazyLoad>
+									<img
+										src={ this.props.image }
+										alt={ this.props.name }
+									/>
+								</LazyLoad>
+							</Button>
+
+							<div className="ab-layout-design-info">
+								<div className="ab-layout-design-title">{ this.props.name }
+									{ <Tooltip text={ this.props.context.favoriteKeys.includes( this.props.itemKey ) ? __( 'Remove from Favorites', 'atomic-blocks' ) : __( 'Add to Favorites', 'atomic-blocks' ) }>
+										<Button
+											key={ 'buttonFavorite' }
+											className='ab-layout-favorite-button'
+											isSmall
+											onClick={ () => {
+												this.props.context.toggleFavorite( this.props.itemKey );
+											} }
+										>
+											<Dashicon
+												icon={ 'heart' }
+												className={ classnames(
+													'ab-layout-icon-favorite',
+													this.props.context.favoriteKeys.includes( this.props.itemKey ) && 'ab-layout-icon-favorite-active'
+												) }
+											/>
+										</Button>
+									</Tooltip> }
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</Fragment>
+		);
+	}
+}

--- a/src/blocks/block-layout/components/layout/layout-library-item-list.js
+++ b/src/blocks/block-layout/components/layout/layout-library-item-list.js
@@ -22,7 +22,7 @@ export default class LayoutLibraryItemList extends Component {
 	}
 
 	render() {
-		const postIdString = this.props.itemKey.match(/\d+/g);
+		const postIdString = this.props.itemKey.match( /\d+/g );
 		const postID = postIdString[0];
 
 		return (
@@ -46,7 +46,7 @@ export default class LayoutLibraryItemList extends Component {
 									post: postID,
 									post_type: 'wp_block',
 									action: 'edit'
-								} ) }
+								}) }
 								target="_blank"
 							>
 								{ __( 'Edit', 'atomic-blocks' ) }

--- a/src/blocks/block-layout/components/layout/layout-library-item-list.js
+++ b/src/blocks/block-layout/components/layout/layout-library-item-list.js
@@ -1,0 +1,60 @@
+/**
+ * Layout Library Card Item.
+ */
+
+ /**
+ * Dependencies.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+const { __ } = wp.i18n;
+const { addQueryArgs } = wp.url;
+const {
+	Component,
+	Fragment
+} = wp.element;
+
+export default class LayoutLibraryItemList extends Component {
+	constructor() {
+		super( ...arguments );
+	}
+
+	render() {
+		const postIdString = this.props.itemKey.match(/\d+/g);
+		const postID = postIdString[0];
+
+		return (
+			<Fragment>
+				<div class="ab-layout-reusable">
+					<div>
+						<a
+							key={ this.props.itemKey }
+							className="ab-layout-insert-button"
+							onClick={ () => {
+								this.props.import( this.props.content );
+							} }
+						>
+							{ this.props.name }
+						</a>
+					</div>
+					<div class="ab-layout-reusable-actions">
+						<span>
+							<a
+								href={ addQueryArgs( 'post.php', {
+									post: postID,
+									post_type: 'wp_block',
+									action: 'edit'
+								} ) }
+								target="_blank"
+							>
+								{ __( 'Edit', 'atomic-blocks' ) }
+							</a>
+						</span>
+					</div>
+				</div>
+			</Fragment>
+		);
+	}
+}

--- a/src/blocks/block-layout/components/layout/layout-library-item.js
+++ b/src/blocks/block-layout/components/layout/layout-library-item.js
@@ -45,8 +45,8 @@ class LayoutLibraryItem extends Component {
 								className="ab-layout-insert-button"
 								isSmall
 								onClick={ () => {
- this.props.import( this.props.content );
-} }
+									this.props.import( this.props.content );
+								} }
 							>
 								<LazyLoad>
 									<img

--- a/src/blocks/block-layout/components/layout/layout-library-item.js
+++ b/src/blocks/block-layout/components/layout/layout-library-item.js
@@ -33,9 +33,9 @@ class LayoutLibraryItem extends Component {
 		return (
 			<Fragment>
 				{ /* Insert the selected layout. */ }
-				{ this.props.currentTab != ( 'ab-layout-tab-reusable-blocks' )
-					? <LayoutLibraryItemCard { ...this.props }/>
-					: <LayoutLibraryItemList { ...this.props }/>
+				{ ( 'ab-layout-tab-reusable-blocks' ) != this.props.currentTab ?
+					<LayoutLibraryItemCard { ...this.props }/> :
+					<LayoutLibraryItemList { ...this.props }/>
 				}
 			</Fragment>
 		);

--- a/src/blocks/block-layout/components/layout/layout-library-item.js
+++ b/src/blocks/block-layout/components/layout/layout-library-item.js
@@ -5,8 +5,8 @@
  /**
  * Dependencies.
  */
-import classnames from 'classnames';
-import LazyLoad from 'react-lazy-load';
+import LayoutLibraryItemCard from './layout-library-item-card';
+import LayoutLibraryItemList from './layout-library-item-list';
 
 /**
  * WordPress dependencies.
@@ -22,11 +22,6 @@ const {
 	Component,
 	Fragment
 } = wp.element;
-const {
-	Button,
-	Dashicon,
-	Tooltip
-} = wp.components;
 
 class LayoutLibraryItem extends Component {
 	constructor() {
@@ -34,53 +29,14 @@ class LayoutLibraryItem extends Component {
 	}
 
 	render() {
+
 		return (
 			<Fragment>
-				<div key={ 'ab-layout-design-' + this.props.itemKey } className="ab-layout-design">
-					<div className="ab-layout-design-inside">
-						<div className="ab-layout-design-item">
-							{ /* Insert the selected layout. */ }
-							<Button
-								key={ this.props.itemKey }
-								className="ab-layout-insert-button"
-								isSmall
-								onClick={ () => {
-									this.props.import( this.props.content );
-								} }
-							>
-								<LazyLoad>
-									<img
-										src={ this.props.image }
-										alt={ this.props.name }
-									/>
-								</LazyLoad>
-							</Button>
-
-							<div className="ab-layout-design-info">
-								<div className="ab-layout-design-title">{ this.props.name }
-									{ <Tooltip text={ this.props.context.favoriteKeys.includes( this.props.itemKey ) ? __( 'Remove from Favorites', 'atomic-blocks' ) : __( 'Add to Favorites', 'atomic-blocks' ) }>
-										<Button
-											key={ 'buttonFavorite' }
-											className='ab-layout-favorite-button'
-											isSmall
-											onClick={ () => {
-												this.props.context.toggleFavorite( this.props.itemKey );
-											} }
-										>
-											<Dashicon
-												icon={ 'heart' }
-												className={ classnames(
-													'ab-layout-icon-favorite',
-													this.props.context.favoriteKeys.includes( this.props.itemKey ) && 'ab-layout-icon-favorite-active'
-												) }
-											/>
-										</Button>
-									</Tooltip> }
-								</div>
-							</div>
-						</div>
-					</div>
-				</div>
+				{ /* Insert the selected layout. */ }
+				{ this.props.currentTab != ( 'ab-layout-tab-reusable-blocks' )
+					? <LayoutLibraryItemCard { ...this.props }/>
+					: <LayoutLibraryItemList { ...this.props }/>
+				}
 			</Fragment>
 		);
 	}

--- a/src/blocks/block-layout/components/layout/layout-library.js
+++ b/src/blocks/block-layout/components/layout/layout-library.js
@@ -54,6 +54,8 @@ export default class LayoutLibrary extends Component {
 			case 'ab-layout-tab-favorites' :
 				component = this.props.context.favorites;
 				break;
+			case 'ab-layout-tab-reusable-blocks' :
+				component = this.props.context.reusableBlocks;
 		}
 
 		return component;
@@ -167,6 +169,7 @@ export default class LayoutLibrary extends Component {
 							aria-label={ __( 'Layout Options', 'atomic-blocks' ) }
 						>
 							{ map( this.props.data, ({ name, key, image, content, category, keywords }) => {
+
 								if ( ( 'all' === this.state.category || category.includes( this.state.category ) ) && ( ! this.state.search || ( keywords && keywords.some( x => x.toLowerCase().includes( this.state.search.toLowerCase() ) ) ) ) ) {
 									return (
 

--- a/src/blocks/block-layout/components/layout/layout-library.js
+++ b/src/blocks/block-layout/components/layout/layout-library.js
@@ -89,7 +89,7 @@ export default class LayoutLibrary extends Component {
 			<Fragment key={ 'layout-library-fragment-' + this.props.clientId }>
 
 				{ /* Category filter and search header. */ }
-				{ this.props.currentTab != ( 'ab-layout-tab-reusable-blocks' ) ?
+				{ ( 'ab-layout-tab-reusable-blocks' ) != this.props.currentTab ?
 					<Fragment>
 						<div className="ab-layout-modal-header">
 							<SelectControl
@@ -155,8 +155,7 @@ export default class LayoutLibrary extends Component {
 								</Tooltip>
 							</div>
 						</div>
-					</Fragment>
-					:
+					</Fragment>					:
 					<Fragment>
 						{ /* Header for reusable blocks. */ }
 						<div className="ab-layout-modal-header ab-layout-modal-header-reusable">
@@ -164,7 +163,7 @@ export default class LayoutLibrary extends Component {
 							<div class="ab-layout-modal-header-reusable-actions">
 								<a
 									className="editor-inserter__manage-reusable-blocks block-editor-inserter__manage-reusable-blocks"
-									href={ addQueryArgs( 'edit.php', { post_type: 'wp_block' } ) }
+									href={ addQueryArgs( 'edit.php', { post_type: 'wp_block' }) }
 									target="_blank"
 								>
 									{ __( 'Manage All Reusable Blocks', 'atomic-blocks' ) }
@@ -189,6 +188,7 @@ export default class LayoutLibrary extends Component {
 
 								if ( ( 'all' === this.state.category || category.includes( this.state.category ) ) && ( ! this.state.search || ( keywords && keywords.some( x => x.toLowerCase().includes( this.state.search.toLowerCase() ) ) ) ) ) {
 									return (
+
 										/* Section and layout items. */
 										<LayoutLibraryItem
 											key={ 'layout-library-item-' + key }

--- a/src/blocks/block-layout/components/layout/layout-library.js
+++ b/src/blocks/block-layout/components/layout/layout-library.js
@@ -84,79 +84,78 @@ export default class LayoutLibrary extends Component {
 				value: item, label: item.charAt( 0 ).toUpperCase() + item.slice( 1 ) };
 		});
 
-		/* Expand each layout full width. */
-		const onZoom = () => {
-			const imageZoom = document.querySelector( '.ab-layout-zoom-button' );
-			imageZoom.parentNode.classList.toggle( 'ab-layout-zoom-layout' );
-		};
-
 		return (
 			<Fragment key={ 'layout-library-fragment-' + this.props.clientId }>
 				{ /* Category filter and search header. */ }
-				<div className="ab-layout-modal-header">
-					<SelectControl
-						key={ 'layout-library-select-categories-' + this.props.clientId }
-						label={ __( 'Layout Categories', 'atomic-blocks' ) }
-						value={ this.state.category }
-						options={ catOptions }
-						onChange={ value => this.setState({ category: value }) }
-					/>
-					<TextControl
-						key={ 'layout-library-search-layouts-' + this.props.clientId }
-						type="text"
-						value={ this.state.search }
-						placeholder={ __( 'Search Layouts', 'atomic-blocks' ) }
-						onChange={ value => this.setState({ search: value }) }
-					/>
-				</div>
 
-				<div className={ 'ab-layout-view' }>
-					{ <div className={ 'ab-layout-view-left' }><p>{ __( 'Showing: ', 'atomic-blocks' ) + this.props.data.length }</p></div> }
+				{ this.props.currentTab != ( 'ab-layout-tab-reusable-blocks' ) && (
+					<Fragment>
+						<div className="ab-layout-modal-header">
+							<SelectControl
+								key={ 'layout-library-select-categories-' + this.props.clientId }
+								label={ __( 'Layout Categories', 'atomic-blocks' ) }
+								value={ this.state.category }
+								options={ catOptions }
+								onChange={ value => this.setState({ category: value }) }
+							/>
+							<TextControl
+								key={ 'layout-library-search-layouts-' + this.props.clientId }
+								type="text"
+								value={ this.state.search }
+								placeholder={ __( 'Search Layouts', 'atomic-blocks' ) }
+								onChange={ value => this.setState({ search: value }) }
+							/>
+						</div>
 
-					{ /* Grid width view. */ }
-					<div className={ 'ab-layout-view-right' }>
-						<Tooltip key={ 'layout-library-grid-view-tooltip-' + this.props.clientId } text={ __( 'Grid View', 'atomic-blocks' ) }>
-							<Button
-								key={ 'layout-library-grid-view-button-' + this.props.clientId }
-								className={ classnames(
-									'grid' === this.state.activeView ? 'is-primary' : null,
-									'ab-layout-grid-view-button'
-								) }
-								isSmall
-								onClick={ () => this.setState({
-									activeView: 'grid'
-								}) }
-							>
-								<Dashicon
-									key={ 'layout-library-grid-view-dashicon-' + this.props.clientId }
-									icon={ 'screenoptions' }
-									className={ 'ab-layout-icon-grid' }
-								/>
-							</Button>
-						</Tooltip>
+						<div className={ 'ab-layout-view' }>
+							{ <div className={ 'ab-layout-view-left' }><p>{ __( 'Showing: ', 'atomic-blocks' ) + this.props.data.length }</p></div> }
 
-						{ /* Full width layout view. */ }
-						<Tooltip key={ 'layout-library-full-view-tooltip-' + this.props.clientId } text={ __( 'Full Width View', 'atomic-blocks' ) }>
-							<Button
-								key={ 'layout-library-full-view-button-' + this.props.clientId }
-								className={ classnames(
-									'full' === this.state.activeView ? 'is-primary' : null,
-									'ab-layout-full-view-button'
-								) }
-								isSmall
-								onClick={ () => this.setState({
-									activeView: 'full'
-								}) }
-							>
-								<Dashicon
-									key={ 'layout-library-full-view-dashicon-' + this.props.clientId }
-									icon={ 'tablet' }
-									className={ 'ab-layout-icon-tablet' }
-								/>
-							</Button>
-						</Tooltip>
-					</div>
-				</div>
+							{ /* Grid width view. */ }
+							<div className={ 'ab-layout-view-right' }>
+								<Tooltip key={ 'layout-library-grid-view-tooltip-' + this.props.clientId } text={ __( 'Grid View', 'atomic-blocks' ) }>
+									<Button
+										key={ 'layout-library-grid-view-button-' + this.props.clientId }
+										className={ classnames(
+											'grid' === this.state.activeView ? 'is-primary' : null,
+											'ab-layout-grid-view-button'
+										) }
+										isSmall
+										onClick={ () => this.setState({
+											activeView: 'grid'
+										}) }
+									>
+										<Dashicon
+											key={ 'layout-library-grid-view-dashicon-' + this.props.clientId }
+											icon={ 'screenoptions' }
+											className={ 'ab-layout-icon-grid' }
+										/>
+									</Button>
+								</Tooltip>
+
+								{ /* Full width layout view. */ }
+								<Tooltip key={ 'layout-library-full-view-tooltip-' + this.props.clientId } text={ __( 'Full Width View', 'atomic-blocks' ) }>
+									<Button
+										key={ 'layout-library-full-view-button-' + this.props.clientId }
+										className={ classnames(
+											'full' === this.state.activeView ? 'is-primary' : null,
+											'ab-layout-full-view-button'
+										) }
+										isSmall
+										onClick={ () => this.setState({
+											activeView: 'full'
+										}) }
+									>
+										<Dashicon
+											key={ 'layout-library-full-view-dashicon-' + this.props.clientId }
+											icon={ 'tablet' }
+											className={ 'ab-layout-icon-tablet' }
+										/>
+									</Button>
+								</Tooltip>
+							</div>
+						</div>
+					</Fragment>
+				) }
 
 				<LayoutsContext.Consumer>
 					{ ( context ) => (

--- a/src/blocks/block-layout/components/layout/layout-library.js
+++ b/src/blocks/block-layout/components/layout/layout-library.js
@@ -16,6 +16,7 @@ import { LayoutsContext } from '../layouts-provider';
  * WordPress dependencies.
  */
 const { __ } = wp.i18n;
+const { addQueryArgs } = wp.url;
 const {
 	Component,
 	Fragment
@@ -86,9 +87,9 @@ export default class LayoutLibrary extends Component {
 
 		return (
 			<Fragment key={ 'layout-library-fragment-' + this.props.clientId }>
-				{ /* Category filter and search header. */ }
 
-				{ this.props.currentTab != ( 'ab-layout-tab-reusable-blocks' ) && (
+				{ /* Category filter and search header. */ }
+				{ this.props.currentTab != ( 'ab-layout-tab-reusable-blocks' ) ?
 					<Fragment>
 						<div className="ab-layout-modal-header">
 							<SelectControl
@@ -155,7 +156,23 @@ export default class LayoutLibrary extends Component {
 							</div>
 						</div>
 					</Fragment>
-				) }
+					:
+					<Fragment>
+						{ /* Header for reusable blocks. */ }
+						<div className="ab-layout-modal-header ab-layout-modal-header-reusable">
+							<div>{ __( 'Reusable Blocks', 'atomic-blocks' ) }</div>
+							<div class="ab-layout-modal-header-reusable-actions">
+								<a
+									className="editor-inserter__manage-reusable-blocks block-editor-inserter__manage-reusable-blocks"
+									href={ addQueryArgs( 'edit.php', { post_type: 'wp_block' } ) }
+									target="_blank"
+								>
+									{ __( 'Manage All Reusable Blocks', 'atomic-blocks' ) }
+								</a>
+							</div>
+						</div>
+					</Fragment>
+				}
 
 				<LayoutsContext.Consumer>
 					{ ( context ) => (
@@ -163,6 +180,7 @@ export default class LayoutLibrary extends Component {
 							key={ 'layout-library-context-button-group-' + this.props.clientId }
 							className={ classnames(
 								'ab-layout-choices',
+								'current-tab-' + this.props.currentTab,
 								'full' === this.state.activeView ? 'ab-layout-view-full' : null,
 							) }
 							aria-label={ __( 'Layout Options', 'atomic-blocks' ) }
@@ -171,7 +189,6 @@ export default class LayoutLibrary extends Component {
 
 								if ( ( 'all' === this.state.category || category.includes( this.state.category ) ) && ( ! this.state.search || ( keywords && keywords.some( x => x.toLowerCase().includes( this.state.search.toLowerCase() ) ) ) ) ) {
 									return (
-
 										/* Section and layout items. */
 										<LayoutLibraryItem
 											key={ 'layout-library-item-' + key }
@@ -181,6 +198,7 @@ export default class LayoutLibrary extends Component {
 											content={ content }
 											context={ context }
 											clientId={ this.props.clientId }
+											currentTab={ this.props.currentTab }
 										/>
 									);
 								}

--- a/src/blocks/block-layout/components/layout/layout-modal.js
+++ b/src/blocks/block-layout/components/layout/layout-modal.js
@@ -3,7 +3,6 @@
  */
 
 import LayoutLibrary from './layout-library';
-import { LayoutsContext } from '../layouts-provider';
 
 /**
  * WordPress dependencies.
@@ -32,6 +31,32 @@ class LayoutModal extends Component {
 		this.setState({ modalOpen: true });
 	}
 	render() {
+		let tabs = [
+			{
+				name: 'ab-layout-tab-sections',
+				title: __( 'Sections', 'atomic-blocks' ),
+				className: 'ab-layout-tab-sections'
+			},
+			{
+				name: 'ab-layout-tab-layouts',
+				title: __( 'Layouts', 'atomic-blocks' ),
+				className: 'ab-layout-tab-layouts'
+			},
+			{
+				name: 'ab-layout-tab-favorites',
+				title: __( 'Favorites', 'atomic-blocks' ),
+				className: 'ab-layout-tab-favorites'
+			}
+		];
+
+		if ( this.props.context.reusableBlocks.length ) {
+			tabs.push({
+				name: 'ab-layout-tab-reusable-blocks',
+				title: __( 'My Layouts', 'atomic-blocks' ),
+				className: 'ab-layout-tab-reusable-blocks'
+			});
+		}
+
 		return (
 			<Fragment key={ 'layout-modal-fragment-' + this.props.clientId }>
 				{ /* Launch the layout modal window */ }
@@ -47,87 +72,79 @@ class LayoutModal extends Component {
 					{ __( 'Layout Library', 'atomic-blocks' ) }
 				</Button>
 				{ this.state.modalOpen ?
-					<LayoutsContext.Consumer key={ 'layouts-context-provider-' + this.props.clientId }>
-						{ ( context ) => (
-							<Modal
-								key={ 'layout-modal-modal-component-' + this.props.clientId }
-								className="ab-layout-modal"
-								title={ __( 'Layout Selector', 'atomic-blocks' ) }
-								onRequestClose={ () => this.setState({ modalOpen: false }) }
-							>
-								<TabPanel
-									key={ 'layout-modal-tabpanel-' + this.props.clientId }
-									className="ab-layout-modal-panel"
-									activeClass="ab-layout-modal-active-tab"
-									onSelect={ ( tabName ) => this.setState({
-										currentTab: tabName
-									}) }
-									tabs={ [
-										{
-											name: 'ab-layout-tab-sections',
-											title: __( 'Sections', 'atomic-blocks' ),
-											className: 'ab-layout-tab-sections'
-										},
-										{
-											name: 'ab-layout-tab-layouts',
-											title: __( 'Layouts', 'atomic-blocks' ),
-											className: 'ab-layout-tab-layouts'
-										},
-										{
-											name: 'ab-layout-tab-favorites',
-											title: __( 'Favorites', 'atomic-blocks' ),
-											className: 'ab-layout-tab-favorites'
+					<Modal
+						key={ 'layout-modal-modal-component-' + this.props.clientId }
+						className="ab-layout-modal"
+						title={ __( 'Layout Selector', 'atomic-blocks' ) }
+						onRequestClose={ () => this.setState({ modalOpen: false }) }
+					>
+						<TabPanel
+							key={ 'layout-modal-tabpanel-' + this.props.clientId }
+							className="ab-layout-modal-panel"
+							activeClass="ab-layout-modal-active-tab"
+							onSelect={ ( tabName ) => this.setState({
+								currentTab: tabName
+							}) }
+							tabs={ tabs }>
+							{
+								( tab ) => {
+
+									let tabContent = __( 'Default tab content', 'atomic-blocks' );
+
+									if ( tab.name ) {
+										if ( 'ab-layout-tab-sections' === tab.name ) {
+											return [
+												<LayoutLibrary
+													key={ 'layout-library-sections-' + this.props.clientId }
+													clientId={ this.props.clientId }
+													currentTab={ this.state.currentTab }
+													data={ this.props.context.sections }
+													context={ this.props.context }
+												/>
+											];
 										}
-									] }>
-									{
-										( tab ) => {
 
-											let tabContent = __( 'Default tab content', 'atomic-blocks' );
+										if ( 'ab-layout-tab-layouts' === tab.name ) {
+											return [
+												<LayoutLibrary
+													key={ 'layout-library-layouts-' + this.props.clientId }
+													clientId={ this.props.clientId }
+													currentTab={ this.state.currentTab }
+													data={ this.props.context.layouts }
+													context={ this.props.context }
+												/>
+											];
+										}
 
-											if ( tab.name ) {
-												if ( 'ab-layout-tab-sections' === tab.name ) {
-													return [
-														<LayoutLibrary
-															key={ 'layout-library-sections-' + this.props.clientId }
-															clientId={ this.props.clientId }
-															currentTab={ this.state.currentTab }
-															data={ context.sections }
-															context={ context }
-														/>
-													];
-												}
+										if ( 'ab-layout-tab-favorites' === tab.name ) {
+											return [
+												<LayoutLibrary
+													key={ 'layout-library-favorites-' + this.props.clientId }
+													clientId={ this.props.clientId }
+													currentTab={ this.state.currentTab }
+													data={ this.props.context.favorites }
+													context={ this.props.context }
+												/>
+											];
+										}
 
-												if ( 'ab-layout-tab-layouts' === tab.name ) {
-													return [
-														<LayoutLibrary
-															key={ 'layout-library-layouts-' + this.props.clientId }
-															clientId={ this.props.clientId }
-															currentTab={ this.state.currentTab }
-															data={ context.layouts }
-															context={ context }
-														/>
-													];
-												}
-
-												if ( 'ab-layout-tab-favorites' === tab.name ) {
-													return [
-														<LayoutLibrary
-															key={ 'layout-library-favorites-' + this.props.clientId }
-															clientId={ this.props.clientId }
-															currentTab={ this.state.currentTab }
-															data={ context.favorites }
-															context={ context }
-														/>
-													];
-												}
-											}
-											return <div>{ tabContent }</div>;
+										if ( 'ab-layout-tab-reusable-blocks' === tab.name ) {
+											return [
+												<LayoutLibrary
+													key={ 'layout-library-reusable-blocks-' + this.props.clientId }
+													clientId={ this.props.clientId }
+													currentTab={ this.state.currentTab }
+													data={ this.props.context.reusableBlocks }
+													context={ this.props.context }
+												/>
+											];
 										}
 									}
-								</TabPanel>
-							</Modal>
-						)}
-					</LayoutsContext.Consumer> :
+									return <div>{ tabContent }</div>;
+								}
+							}
+						</TabPanel>
+					</Modal> :
 					null }
 			</Fragment>
 		);

--- a/src/blocks/block-layout/components/layout/layout-modal.js
+++ b/src/blocks/block-layout/components/layout/layout-modal.js
@@ -76,7 +76,10 @@ class LayoutModal extends Component {
 						key={ 'layout-modal-modal-component-' + this.props.clientId }
 						className="ab-layout-modal"
 						title={ __( 'Layout Selector', 'atomic-blocks' ) }
-						onRequestClose={ () => this.setState({ modalOpen: false }) }
+						onRequestClose={ () => this.setState({
+							modalOpen: false,
+							currentTab: null
+						}) }
 					>
 						<TabPanel
 							key={ 'layout-modal-tabpanel-' + this.props.clientId }

--- a/src/blocks/block-layout/components/layout/layout-modal.js
+++ b/src/blocks/block-layout/components/layout/layout-modal.js
@@ -52,7 +52,7 @@ class LayoutModal extends Component {
 		if ( this.props.context.reusableBlocks.length ) {
 			tabs.push({
 				name: 'ab-layout-tab-reusable-blocks',
-				title: __( 'My Layouts', 'atomic-blocks' ),
+				title: __( 'Reusable Blocks', 'atomic-blocks' ),
 				className: 'ab-layout-tab-reusable-blocks'
 			});
 		}

--- a/src/blocks/block-layout/components/layouts-provider.js
+++ b/src/blocks/block-layout/components/layouts-provider.js
@@ -14,7 +14,8 @@ export const LayoutsContext = createContext({
 	favoriteKeys: '',
 	layouts: '',
 	sections: '',
-	all: ''
+	all: '',
+	reusableBlocks: ''
 });
 
 export default class LayoutsProvider extends Component {
@@ -23,7 +24,8 @@ export default class LayoutsProvider extends Component {
 		favoriteKeys: '',
 		layouts: '',
 		sections: '',
-		all: ''
+		all: '',
+		reusableBlocks: ''
 	}
 
 	/**
@@ -86,8 +88,8 @@ export default class LayoutsProvider extends Component {
 			}
 		).then(
 			( favorites ) => {
- return favorites;
-}
+				return favorites;
+			}
 		).catch(
 			error => console.error( error )
 		);
@@ -109,8 +111,8 @@ export default class LayoutsProvider extends Component {
 			}
 		).then(
 			( favorites ) => {
- return favorites;
-}
+				return favorites;
+			}
 		).catch(
 			error => console.error( error )
 		);
@@ -130,15 +132,22 @@ export default class LayoutsProvider extends Component {
 				'path': '/atomicblocks/v1/layouts/all'
 			}
 		).then( async components => {
-			let layouts   = [];
-			let sections  = [];
+			let layouts = [];
+			let sections = [];
+			let reusableBlocks = [];
 			let favorites = [];
 
 			Object.values( components ).forEach( function( item ) {
 				if ( 'layout' === item.type ) {
 					layouts.push( item );
-				} else {
+				}
+
+				if ( 'section' === item.type ) {
 					sections.push( item );
+				}
+
+				if ( 'wp_block' === item.type ) {
+					reusableBlocks.push( item );
 				}
 
 				if ( favoriteKeys.includes( item.key ) ) {
@@ -151,7 +160,8 @@ export default class LayoutsProvider extends Component {
 				layouts: layouts,
 				sections: sections,
 				favorites: favorites,
-				favoriteKeys: favoriteKeys
+				favoriteKeys: favoriteKeys,
+				reusableBlocks: reusableBlocks
 			});
 		});
 	}
@@ -164,6 +174,7 @@ export default class LayoutsProvider extends Component {
 					layouts: this.state.layouts,
 					sections: this.state.sections,
 					all: this.state.all,
+					reusableBlocks: this.state.reusableBlocks,
 					toggleFavorite: async( key ) => {
 
 						let favoriteKeys = await this.getFavoriteKeys();

--- a/src/blocks/block-layout/styles/editor.scss
+++ b/src/blocks/block-layout/styles/editor.scss
@@ -266,4 +266,69 @@
 	}
 }
 
+.current-tab-ab-layout-tab-reusable-blocks.ab-layout-choices {
+	display: block;
+	a {
+		text-decoration: none;
+	}
+}
 
+.ab-layout-reusable {
+	display: -ms-flexbox;
+	display: flex;
+	-ms-flex-flow: row wrap;
+	flex-flow: row wrap;
+	-ms-flex-pack: distribute;
+	justify-content: space-around;
+	font-size: 14px;
+	font-weight: 600;
+	padding: 18px;
+
+	&:nth-child(even) {
+		background: #f2f2f2;
+	}
+
+	&> div {
+		display: inline;
+		-ms-flex: 1 0 0px;
+		flex: 1 0 0;
+	}
+
+	a:hover {
+		cursor: pointer;
+	}
+
+	&:hover {
+		.ab-layout-reusable-actions {
+			opacity: 1;
+		}
+	}
+}
+
+.ab-layout-reusable-actions {
+	text-align: right;
+	font-size: 14px;
+	font-weight: normal;
+	opacity: 1;
+	transition: .1s ease;
+
+	span {
+		padding-left: 15px;
+	}
+	i {
+		font-size: 17px;
+		margin-right: 2px;
+	}
+}
+
+.ab-layout-modal .ab-layout-modal-header-reusable {
+	margin-bottom: 0;
+	font-weight: bold;
+	a {
+		text-decoration: none;
+	}
+}
+
+.ab-layout-modal-header-reusable-actions {
+	text-align: right;
+}


### PR DESCRIPTION
**Summary of change:**
- Adds support for additional layouts via `atomic_blocks_additional_layout_components` filter.
- Adds additional Reusable Blocks tab to modal.

**Suggested Changelog Entry:**
- Adds support for additional layouts via `atomic_blocks_additional_layout_components` filter.
