### PR TITLE
Add ability to unregister layout components. #255

### DIFF
--- a/includes/layout/class-component-registry.php
+++ b/includes/layout/class-component-registry.php
@@ -113,6 +113,25 @@ final class Component_Registry {
 	}
 
 	/**
+	 * Removes an existing component from the registry.
+	 *
+	 * @param string $key The unique layout key to be removed.
+	 */
+	public static function remove( $key ) {
+		if ( empty( $key ) ) {
+			return;
+		}
+
+		$key = sanitize_key( $key );
+
+		if ( ! isset( self::$layouts[ $key ] ) ) {
+			return;
+		}
+
+		unset( self::$layouts[ $key ] );
+	}
+
+	/**
 	 * Gets a component from the registry.
 	 *
 	 * @param string $type The component type.

--- a/includes/layout/class-component-registry.php
+++ b/includes/layout/class-component-registry.php
@@ -115,20 +115,42 @@ final class Component_Registry {
 	/**
 	 * Removes an existing component from the registry.
 	 *
+	 * @param string $type The component type to unregister.
 	 * @param string $key The unique layout key to be removed.
+	 *
+	 * @throws Exception If the required data is not provided or the specified component is not registered.
+	 * @throws InvalidArgumentException If an unsupported component type is provided.
 	 */
-	public static function remove( $key ) {
+	public static function remove( $type, $key ) {
+
+		if ( empty( $type ) || ! in_array( $type, self::$supported_component_types, true ) ) {
+			throw new InvalidArgumentException( sprintf( esc_html__( 'You must supply a valid component type in %s.', 'atomic-blocks' ), __METHOD__ ) );
+		}
+
 		if ( empty( $key ) ) {
-			return;
+			throw new InvalidArgumentException( sprintf( esc_html__( 'You must supply a valid component key in %s.', 'atomic-blocks' ), __METHOD__ ) );
 		}
 
 		$key = sanitize_key( $key );
 
-		if ( ! isset( self::$layouts[ $key ] ) ) {
-			return;
+		switch ( $type ) {
+			case 'layout':
+				if ( empty( self::$layouts[ $key ] ) ) {
+					/* translators: The requested components unique key. */
+					throw new Exception( sprintf( esc_html__( 'The %s layout is not registered.', 'atomic-blocks' ), $key ) );
+				}
+				unset( self::$layouts[ $key ] );
+				break;
+
+			case 'section':
+				if ( empty( self::$sections[ $key ] ) ) {
+					/* translators: The requested components unique key. */
+					throw new Exception( sprintf( esc_html__( 'The %s section is not registered.', 'atomic-blocks' ), $key ) );
+				}
+				unset( self::$sections[ $key ] );
+				break;
 		}
 
-		unset( self::$layouts[ $key ] );
 	}
 
 	/**

--- a/includes/layout/layout-functions.php
+++ b/includes/layout/layout-functions.php
@@ -28,6 +28,17 @@ function atomic_blocks_register_layout_component( array $data ) {
 }
 
 /**
+ * Unregisters the specified layout component from the Component Registry
+ * for use in the Layouts block.
+ *
+ * @param string $key The unique layout key to be removed.
+ */
+function atomic_blocks_unregister_layout_component( $key ) {
+	$registry = Component_Registry::instance();
+	$registry::remove( $key );
+}
+
+/**
  * Retrieves the specified layout component.
  *
  * @param string $type The layout component type.

--- a/includes/layout/layout-functions.php
+++ b/includes/layout/layout-functions.php
@@ -31,11 +31,18 @@ function atomic_blocks_register_layout_component( array $data ) {
  * Unregisters the specified layout component from the Component Registry
  * for use in the Layouts block.
  *
- * @param string $key The unique layout key to be removed.
+ * @return mixed Boolean true if component unregistered. WP_Error object if an error occurs.
+ * @param string $type The component type to be unregistered.
+ * @param string $key The unique layout key to be unregistered.
  */
-function atomic_blocks_unregister_layout_component( $key ) {
+function atomic_blocks_unregister_layout_component( $type, $key ) {
 	$registry = Component_Registry::instance();
-	$registry::remove( $key );
+	try {
+		$registry::remove( $type, $key );
+		return true;
+	} catch ( Exception $exception ) {
+		return new WP_Error( esc_html( $exception->getMessage() ) );
+	}
 }
 
 /**


### PR DESCRIPTION
**Summary of change:**
Adds `AtomicBlocks\Layouts\Component_Registry\remove()` method to allow for unregistering layouts.

Adds `atomic_blocks_unregister_layout_component()` helper function that uses aforementioned method to unregister layout components.

**Have the changes in this PR been added to the documentation for this project?**
Not yet.

**How to test:**
Add the following code to a custom plugin and ensure the Business layout is removed.
```
add_action( 'plugins_loaded', function() {
	atomic_blocks_unregister_layout_component( 'layout', 'ab_layout_business_1' );
}, 12 );
```


<!-- If this PR is in reference to an existing issue, link it here. -->
**Closes:** #255

**Suggested Changelog Entry:**
<!-- Provide a short description of the changes in this PR for inclusion in the changelog. -->

<!-- You can use this space to provide any additional information that may be relevant to this PR -->
