### PR TITLE
5.3 support

### DIFF
--- a/src/blocks/block-layout/styles/editor.scss
+++ b/src/blocks/block-layout/styles/editor.scss
@@ -370,3 +370,9 @@
 		margin: 0 5px;
 	}
 }
+
+div[data-type*="atomic-blocks/ab-columns"][data-align="full"],
+div[data-type*="atomic-blocks/ab-container"][data-align="full"] {
+	margin-top: auto;
+	margin-bottom: auto;
+}

--- a/src/blocks/block-layout/styles/style.scss
+++ b/src/blocks/block-layout/styles/style.scss
@@ -107,3 +107,9 @@
 		}
 	}
  }
+
+div[class*="ab-section-"].alignfull,
+div[class*="ab-layout-"].alignfull {
+	margin-top: auto;
+	margin-bottom: auto;
+}

--- a/src/blocks/block-layout/styles/style.scss
+++ b/src/blocks/block-layout/styles/style.scss
@@ -108,8 +108,17 @@
 	}
  }
 
+/**
+ * Twenty Twenty theme styles
+ * Let's look at loading these conditionally if the theme is active
+ */
+
 div[class*="ab-section-"].alignfull,
 div[class*="ab-layout-"].alignfull {
 	margin-top: auto;
 	margin-bottom: auto;
+}
+
+.page .section-inner.thin {
+	padding-top: 0;
 }

--- a/src/blocks/block-layout/styles/style.scss
+++ b/src/blocks/block-layout/styles/style.scss
@@ -118,7 +118,3 @@ div[class*="ab-layout-"].alignfull {
 	margin-top: auto;
 	margin-bottom: auto;
 }
-
-.page .section-inner.thin {
-	padding-top: 0;
-}


### PR DESCRIPTION
Add a few stylistic fixes for 5.3, including for the 2020 theme.

**How to test:**
Check out the 5.3 branch, fire up 5.3 via the beta tester plugin and Gutenberg plugin, check out the alignment and margins of section and layout blocks added to the editor. They should line up nicely and not have big margins between them.

**Suggested Changelog Entry:**
Style improvements for WP 5.3 and TwentyTwenty.