### PR TITLE
Add AB Pro callouts to editor and GS page.

### DIFF
--- a/dist/getting-started/getting-started.css
+++ b/dist/getting-started/getting-started.css
@@ -1008,9 +1008,11 @@
 	background: #e4e4fd;
     border: solid 2px #5b3fd6;
     border-radius: 5px;
-    padding: 15px;
+    padding: 15px 15px 15px 80px;
 	color: #4d36b7;
-	margin-bottom: 60px;
+	margin-bottom: 30px;
+	min-height: 78px;
+	position: relative;
 }
 
 .ab-block-pro-notice p {
@@ -1023,4 +1025,14 @@
 
 .ab-block-pro-notice a:hover {
 	text-decoration: underline;
+}
+
+.ab-block-pro-notice .fa-bullhorn {
+	background: #5c45c9;
+    padding: 15px;
+    border-radius: 100px;
+    color: #fff;
+	position: absolute;
+	left: 15px;
+	top: 22px;
 }

--- a/dist/getting-started/getting-started.css
+++ b/dist/getting-started/getting-started.css
@@ -1003,3 +1003,24 @@
 		margin-left: 0;
 	}
 }
+
+.ab-block-pro-notice {
+	background: #e4e4fd;
+    border: solid 2px #5b3fd6;
+    border-radius: 5px;
+    padding: 15px;
+	color: #4d36b7;
+	margin-bottom: 60px;
+}
+
+.ab-block-pro-notice p {
+	margin: 0;
+}
+
+.ab-block-pro-notice a {
+	font-weight: bold;
+}
+
+.ab-block-pro-notice a:hover {
+	text-decoration: underline;
+}

--- a/dist/getting-started/getting-started.php
+++ b/dist/getting-started/getting-started.php
@@ -145,11 +145,13 @@ function atomic_blocks_getting_started_page() {
 			<div id="panel" class="panel">
 				<div id="atomic-blocks-panel" class="panel-left visible">
 					<div class="ab-block-split clearfix">
-						<div class="ab-block-pro-notice">
-							<p>
-								<?php echo sprintf( esc_html__( 'Atomic Blocks Pro expands the library of blocks and increases functionality and control to meet all your page building needs. %1$s', 'atomic-blocks' ), '<a target="_blank" href=" ' . esc_url( 'https://wpengine.com/blog/introducing-atomic-blocks-pro-a-premium-collection-of-wordpress-content-blocks/' ) . ' ">Explore Atomic Blocks Pro &rarr;</a>' ); ?>
-							</p>
-						</div>
+						<?php if( function_exists( 'is_wpe' ) && is_wpe() ) { ?>
+							<div class="ab-block-pro-notice">
+								<p>
+									<?php echo sprintf( esc_html__( 'Atomic Blocks Pro expands the library of blocks and increases functionality and control to meet all your page building needs. %1$s', 'atomic-blocks' ), '<a target="_blank" href=" ' . esc_url( 'https://wpengine.com/blog/introducing-atomic-blocks-pro-a-premium-collection-of-wordpress-content-blocks/' ) . ' ">Explore Atomic Blocks Pro &rarr;</a>' ); ?>
+								</p>
+							</div>
+						<?php } ?>
 						<div class="ab-block-split-left">
 							<div class="ab-titles">
 								<h2><?php esc_html_e( 'Welcome to the future of site building with Gutenberg and Atomic Blocks!', 'atomic-blocks' ); ?></h2>

--- a/dist/getting-started/getting-started.php
+++ b/dist/getting-started/getting-started.php
@@ -146,11 +146,14 @@ function atomic_blocks_getting_started_page() {
 				<div id="atomic-blocks-panel" class="panel-left visible">
 					<div class="ab-block-split clearfix">
 						<div class="ab-block-split-left">
-							<?php if( function_exists( 'is_wpe' ) && is_wpe() ) { ?>
+							<?php if ( function_exists( 'is_wpe' ) && is_wpe() ) { ?>
 								<div class="ab-block-pro-notice">
 									<i class="fa fa-bullhorn"></i>
 									<p>
-										<?php echo sprintf( esc_html__( 'Atomic Blocks Pro expands the library of blocks and increases functionality and control to meet all your page building needs. %1$s', 'atomic-blocks' ), '<a target="_blank" href=" ' . esc_url( 'https://wpengine.com/blog/introducing-atomic-blocks-pro-a-premium-collection-of-wordpress-content-blocks/' ) . ' ">Explore Atomic Blocks Pro &rarr;</a>' ); ?>
+										<?php
+										/* translators: %1$s URL to site about Atomic Blocks Pro */
+										printf( esc_html__( 'Atomic Blocks Pro expands the library of blocks and increases functionality and control to meet all your page building needs. %1$s', 'atomic-blocks' ), '<a target="_blank" rel="noopener noreferrer" href="https://wpengine.com/blog/introducing-atomic-blocks-pro-a-premium-collection-of-wordpress-content-blocks/">' . esc_html__( 'Explore Atomic Blocks Pro &rarr;', 'atomic-blocks' ) . '</a>' );
+										?>
 									</p>
 								</div>
 							<?php } ?>

--- a/dist/getting-started/getting-started.php
+++ b/dist/getting-started/getting-started.php
@@ -147,7 +147,7 @@ function atomic_blocks_getting_started_page() {
 					<div class="ab-block-split clearfix">
 						<div class="ab-block-pro-notice">
 							<p>
-								<?php echo sprintf( esc_html__( 'Atomic Blocks Pro expands the library of blocks and increases functionality and control to meet all your page building needs. %1$s', 'atomic-blocks' ), '<a href=" ' . esc_url( 'https://wpengine.com/' ) . ' ">Explore Atomic Blocks Pro &rarr;</a>' ); ?>
+								<?php echo sprintf( esc_html__( 'Atomic Blocks Pro expands the library of blocks and increases functionality and control to meet all your page building needs. %1$s', 'atomic-blocks' ), '<a target="_blank" href=" ' . esc_url( 'https://wpengine.com/blog/introducing-atomic-blocks-pro-a-premium-collection-of-wordpress-content-blocks/' ) . ' ">Explore Atomic Blocks Pro &rarr;</a>' ); ?>
 							</p>
 						</div>
 						<div class="ab-block-split-left">

--- a/dist/getting-started/getting-started.php
+++ b/dist/getting-started/getting-started.php
@@ -145,6 +145,11 @@ function atomic_blocks_getting_started_page() {
 			<div id="panel" class="panel">
 				<div id="atomic-blocks-panel" class="panel-left visible">
 					<div class="ab-block-split clearfix">
+						<div class="ab-block-pro-notice">
+							<p>
+								<?php echo sprintf( esc_html__( 'Atomic Blocks Pro expands the library of blocks and increases functionality and control to meet all your page building needs. %1$s', 'atomic-blocks' ), '<a href=" ' . esc_url( 'https://wpengine.com/' ) . ' ">Explore Atomic Blocks Pro &rarr;</a>' ); ?>
+							</p>
+						</div>
 						<div class="ab-block-split-left">
 							<div class="ab-titles">
 								<h2><?php esc_html_e( 'Welcome to the future of site building with Gutenberg and Atomic Blocks!', 'atomic-blocks' ); ?></h2>

--- a/dist/getting-started/getting-started.php
+++ b/dist/getting-started/getting-started.php
@@ -145,14 +145,15 @@ function atomic_blocks_getting_started_page() {
 			<div id="panel" class="panel">
 				<div id="atomic-blocks-panel" class="panel-left visible">
 					<div class="ab-block-split clearfix">
-						<?php if( function_exists( 'is_wpe' ) && is_wpe() ) { ?>
-							<div class="ab-block-pro-notice">
-								<p>
-									<?php echo sprintf( esc_html__( 'Atomic Blocks Pro expands the library of blocks and increases functionality and control to meet all your page building needs. %1$s', 'atomic-blocks' ), '<a target="_blank" href=" ' . esc_url( 'https://wpengine.com/blog/introducing-atomic-blocks-pro-a-premium-collection-of-wordpress-content-blocks/' ) . ' ">Explore Atomic Blocks Pro &rarr;</a>' ); ?>
-								</p>
-							</div>
-						<?php } ?>
 						<div class="ab-block-split-left">
+							<?php if( function_exists( 'is_wpe' ) && is_wpe() ) { ?>
+								<div class="ab-block-pro-notice">
+									<i class="fa fa-bullhorn"></i>
+									<p>
+										<?php echo sprintf( esc_html__( 'Atomic Blocks Pro expands the library of blocks and increases functionality and control to meet all your page building needs. %1$s', 'atomic-blocks' ), '<a target="_blank" href=" ' . esc_url( 'https://wpengine.com/blog/introducing-atomic-blocks-pro-a-premium-collection-of-wordpress-content-blocks/' ) . ' ">Explore Atomic Blocks Pro &rarr;</a>' ); ?>
+									</p>
+								</div>
+							<?php } ?>
 							<div class="ab-titles">
 								<h2><?php esc_html_e( 'Welcome to the future of site building with Gutenberg and Atomic Blocks!', 'atomic-blocks' ); ?></h2>
 								<p><?php esc_html_e( 'The Atomic Blocks collection is now ready to use in your posts and pages. Simply search for "atomic" or "ab" in the block inserter to display the Atomic Blocks collection. Check out the help file link above for detailed instructions!', 'atomic-blocks' ); ?></p>

--- a/dist/init.php
+++ b/dist/init.php
@@ -84,6 +84,7 @@ function atomic_blocks_editor_assets() {
 		array(
 			'rest_url'      => esc_url( rest_url() ),
 			'pro_activated' => function_exists( '\AtomicBlocksPro\plugin_loader' ),
+			'is_wpe' => function_exists( 'is_wpe' ),
 		)
 	);
 }

--- a/dist/init.php
+++ b/dist/init.php
@@ -84,7 +84,7 @@ function atomic_blocks_editor_assets() {
 		array(
 			'rest_url'      => esc_url( rest_url() ),
 			'pro_activated' => function_exists( '\AtomicBlocksPro\plugin_loader' ),
-			'is_wpe' => function_exists( 'is_wpe' ),
+			'is_wpe'        => function_exists( 'is_wpe' ),
 		)
 	);
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -31,8 +31,10 @@
 	<!-- WordPress minimum version compatibility -->
 	<config name="minimum_supported_wp_version" value="5.0"/>
 
+	<rule ref="WordPress-Extra">
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+	</rule><!-- Includes WordPress-Core -->
 
-	<rule ref="WordPress-Extra"/><!-- Includes WordPress-Core -->
 	<rule ref="WordPress-Docs"/>
 
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">

--- a/src/blocks/block-layout/components/layout/layout-library.js
+++ b/src/blocks/block-layout/components/layout/layout-library.js
@@ -115,7 +115,7 @@ export default class LayoutLibrary extends Component {
 							<div className={ 'ab-layout-view-left' }>
 								<p>{ __( 'Get more sections & layouts with ', 'atomic-blocks' ) }
 									<a
-										href={ 'https://wpengine.com' }
+										href={ 'https://wpengine.com/blog/introducing-atomic-blocks-pro-a-premium-collection-of-wordpress-content-blocks/' }
 										target="_blank"
 									>{ __( 'Atomic Blocks Pro', 'atomic-blocks' ) } &rarr;</a>
 								</p>

--- a/src/blocks/block-layout/components/layout/layout-library.js
+++ b/src/blocks/block-layout/components/layout/layout-library.js
@@ -109,14 +109,18 @@ export default class LayoutLibrary extends Component {
 						</div>
 
 						<div className={ 'ab-layout-view' }>
-							{ <div className={ 'ab-layout-view-left' }>
+
+							{ atomic_globals.pro_activated ?
+							<div className={ 'ab-layout-view-left' }><p>{ __( 'Showing: ', 'atomic-blocks' ) + this.props.data.length }</p></div> :
+							<div className={ 'ab-layout-view-left' }>
 								<p>{ __( 'Get more sections & layouts with ', 'atomic-blocks' ) }
 									<a
 										href={ 'https://wpengine.com' }
 										target="_blank"
 									>{ __( 'Atomic Blocks Pro', 'atomic-blocks' ) } &rarr;</a>
 								</p>
-							</div> }
+							</div>
+							}
 
 							{ /* Grid width view. */ }
 							<div className={ 'ab-layout-view-right' }>

--- a/src/blocks/block-layout/components/layout/layout-library.js
+++ b/src/blocks/block-layout/components/layout/layout-library.js
@@ -110,16 +110,18 @@ export default class LayoutLibrary extends Component {
 
 						<div className={ 'ab-layout-view' }>
 
-							{ atomic_globals.pro_activated ?
-							<div className={ 'ab-layout-view-left' }><p>{ __( 'Showing: ', 'atomic-blocks' ) + this.props.data.length }</p></div> :
-							<div className={ 'ab-layout-view-left' }>
-								<p>{ __( 'Get more sections & layouts with ', 'atomic-blocks' ) }
-									<a
-										href={ 'https://wpengine.com/blog/introducing-atomic-blocks-pro-a-premium-collection-of-wordpress-content-blocks/' }
-										target="_blank"
-									>{ __( 'Atomic Blocks Pro', 'atomic-blocks' ) } &rarr;</a>
-								</p>
-							</div>
+
+							{ atomic_globals.is_wpe && atomic_globals.pro_activated ?
+								<div className={ 'ab-layout-view-left' }>
+									<p>{ __( 'Get more sections & layouts with ', 'atomic-blocks' ) }
+										<a
+											href={ 'https://wpengine.com/blog/introducing-atomic-blocks-pro-a-premium-collection-of-wordpress-content-blocks/' }
+											target="_blank"
+										>{ __( 'Atomic Blocks Pro', 'atomic-blocks' ) } &rarr;</a>
+									</p>
+								</div>
+								:
+								<div className={ 'ab-layout-view-left' }><p>{ __( 'Showing: ', 'atomic-blocks' ) + this.props.data.length }</p></div>
 							}
 
 							{ /* Grid width view. */ }

--- a/src/blocks/block-layout/components/layout/layout-library.js
+++ b/src/blocks/block-layout/components/layout/layout-library.js
@@ -111,7 +111,7 @@ export default class LayoutLibrary extends Component {
 						<div className={ 'ab-layout-view' }>
 
 
-							{ atomic_globals.is_wpe && atomic_globals.pro_activated ?
+							{ atomic_globals.is_wpe && !atomic_globals.pro_activated ?
 								<div className={ 'ab-layout-view-left' }>
 									<p>{ __( 'Get more sections & layouts with ', 'atomic-blocks' ) }
 										<a

--- a/src/blocks/block-layout/components/layout/layout-library.js
+++ b/src/blocks/block-layout/components/layout/layout-library.js
@@ -109,7 +109,14 @@ export default class LayoutLibrary extends Component {
 						</div>
 
 						<div className={ 'ab-layout-view' }>
-							{ <div className={ 'ab-layout-view-left' }><p>{ __( 'Showing: ', 'atomic-blocks' ) + this.props.data.length }</p></div> }
+							{ <div className={ 'ab-layout-view-left' }>
+								<p>{ __( 'Get more sections & layouts with ', 'atomic-blocks' ) }
+									<a
+										href={ 'https://wpengine.com' }
+										target="_blank"
+									>{ __( 'Atomic Blocks Pro', 'atomic-blocks' ) } &rarr;</a>
+								</p>
+							</div> }
 
 							{ /* Grid width view. */ }
 							<div className={ 'ab-layout-view-right' }>

--- a/src/blocks/block-layout/components/layout/layout-library.js
+++ b/src/blocks/block-layout/components/layout/layout-library.js
@@ -111,7 +111,7 @@ export default class LayoutLibrary extends Component {
 						<div className={ 'ab-layout-view' }>
 
 
-							{ atomic_globals.is_wpe && !atomic_globals.pro_activated ?
+							{ atomic_globals.is_wpe && ! atomic_globals.pro_activated ?
 								<div className={ 'ab-layout-view-left' }>
 									<p>{ __( 'Get more sections & layouts with ', 'atomic-blocks' ) }
 										<a
@@ -119,9 +119,7 @@ export default class LayoutLibrary extends Component {
 											target="_blank"
 										>{ __( 'Atomic Blocks Pro', 'atomic-blocks' ) } &rarr;</a>
 									</p>
-								</div>
-								:
-								<div className={ 'ab-layout-view-left' }><p>{ __( 'Showing: ', 'atomic-blocks' ) + this.props.data.length }</p></div>
+								</div> : <div className={ 'ab-layout-view-left' }><p>{ __( 'Showing: ', 'atomic-blocks' ) + this.props.data.length }</p></div>
 							}
 
 							{ /* Grid width view. */ }

--- a/src/blocks/block-layout/styles/editor.scss
+++ b/src/blocks/block-layout/styles/editor.scss
@@ -113,6 +113,10 @@
 			margin: 0;
 			line-height: 2.2em;
 		}
+		a {
+			font-weight: bold;
+			color: #027bba;
+		}
 	}
 
 	.ab-layout-view-right {


### PR DESCRIPTION
**Summary of change:**
Add CTA callouts to AB Pro in the GS page and layout modal.

**How to test:**
Check out ctaCallouts and run build assets to compile the latest code. Check out the Getting Started page and the layout modal to preview the callouts.