### PR TITLE
Allow HubSpot to capture Newsletter emails

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -31,8 +31,10 @@
 	<!-- WordPress minimum version compatibility -->
 	<config name="minimum_supported_wp_version" value="5.0"/>
 
+	<rule ref="WordPress-Extra">
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+	</rule><!-- Includes WordPress-Core -->
 
-	<rule ref="WordPress-Extra"/><!-- Includes WordPress-Core -->
 	<rule ref="WordPress-Docs"/>
 
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">

--- a/src/blocks/block-newsletter/index.php
+++ b/src/blocks/block-newsletter/index.php
@@ -37,7 +37,9 @@ function atomic_blocks_render_newsletter_block( $attributes ) {
 
 	$amp_endpoint = function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
 
-	if ( ! $amp_endpoint ) {
+	$hubspot_installed = is_plugin_active( 'leadin/leadin.php' );
+
+	if ( ! $amp_endpoint && ! $hubspot_installed ) {
 		wp_enqueue_script( 'atomic-blocks-newsletter-functions' );
 	}
 


### PR DESCRIPTION
This PR removes the JS code from the submit process of the Newsletter block when the plugin `leadin` (HubSpot) is activated. It also adds a rule to ignore Short Array Syntax.