### PR TITLE
Change way we detect HubSpot plugin

### DIFF
--- a/src/blocks/block-newsletter/index.php
+++ b/src/blocks/block-newsletter/index.php
@@ -37,7 +37,7 @@ function atomic_blocks_render_newsletter_block( $attributes ) {
 
 	$amp_endpoint = function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
 
-	$hubspot_installed = is_plugin_active( 'leadin/leadin.php' );
+	$hubspot_installed = defined( 'LEADIN_PLUGIN_VERSION' );
 
 	if ( ! $amp_endpoint && ! $hubspot_installed ) {
 		wp_enqueue_script( 'atomic-blocks-newsletter-functions' );


### PR DESCRIPTION
Fix issue with `is_plugin_active` not being available. Introduced in https://github.com/studiopress/atomic-blocks/pull/267.

