### PR TITLE
Add class to setting description text

### DIFF
--- a/dist/getting-started/pages/settings-general.php
+++ b/dist/getting-started/pages/settings-general.php
@@ -20,7 +20,7 @@ $atomic_blocks_mailchimp_api_key = get_option( 'atomic_blocks_mailchimp_api_key'
 					<input type="text" id="atomic-blocks-settings[mailchimp-api-key]" name="atomic-blocks-settings[mailchimp-api-key]" size="40" value="<?php echo esc_attr( $atomic_blocks_mailchimp_api_key ); ?>" />
 					<?php
 						$atomic_blocks_mailchimp_api_key_link = sprintf(
-							'<p><a href="%1$s" target="_blank" rel="noreferrer noopener">%2$s</a></p>',
+							'<p class="atomic-blocks-settings-description"><a href="%1$s" target="_blank" rel="noreferrer noopener">%2$s</a></p>',
 							'https://mailchimp.com/help/about-api-keys/',
 							esc_html__( 'Find your Mailchimp API key.', 'atomic-blocks' )
 						);


### PR DESCRIPTION
**Summary of change:**
Add a class to style the description text under the Mailchimp setting.

**How to test:**
Visit the settings page and check the class on the Mailchimp setting.

**Suggested Changelog Entry:**
Add a class to style the description text under the Mailchimp setting.