### PR TITLE
Fix invalid content warning when clearing button colors

### DIFF
--- a/src/blocks/block-button/index.js
+++ b/src/blocks/block-button/index.js
@@ -39,7 +39,7 @@ class ABButtonBlock extends Component {
 	render() {
 
 		// Setup the attributes
-		const { attributes: { buttonText, buttonUrl, buttonAlignment, buttonBackgroundColor, buttonTextColor, buttonSize, buttonShape, buttonTarget }, isSelected, className, setAttributes } = this.props;
+		const { attributes: { buttonText, buttonUrl, buttonAlignment, buttonBackgroundColor, buttonTextColor, buttonSize, buttonShape }, isSelected, setAttributes } = this.props;
 
 		return [
 
@@ -72,8 +72,8 @@ class ABButtonBlock extends Component {
 						buttonSize,
 					) }
 					style={ {
-						color: buttonTextColor,
-						backgroundColor: buttonBackgroundColor
+						color: buttonTextColor ? buttonTextColor : '#ffffff',
+						backgroundColor: buttonBackgroundColor ? buttonBackgroundColor : '#3373dc'
 					} }
 					onChange={ ( value ) => setAttributes({ buttonText: value }) }
 				/>
@@ -130,11 +130,9 @@ registerBlockType( 'atomic-blocks/ab-button', {
 		},
 		buttonBackgroundColor: {
 			type: 'string',
-			default: '#3373dc'
 		},
 		buttonTextColor: {
 			type: 'string',
-			default: '#ffffff'
 		},
 		buttonSize: {
 			type: 'string',
@@ -157,7 +155,7 @@ registerBlockType( 'atomic-blocks/ab-button', {
 	save: function( props ) {
 
 		// Setup the attributes
-		const { buttonText, buttonUrl, buttonAlignment, buttonBackgroundColor, buttonTextColor, buttonSize, buttonShape, buttonTarget } = props.attributes;
+		const { buttonText, buttonUrl, buttonBackgroundColor, buttonTextColor, buttonSize, buttonShape, buttonTarget } = props.attributes;
 
 		// Save the block markup for the front end
 		return (
@@ -174,8 +172,8 @@ registerBlockType( 'atomic-blocks/ab-button', {
 							buttonSize,
 						) }
 						style={ {
-							color: buttonTextColor,
-							backgroundColor: buttonBackgroundColor
+							color: buttonTextColor ? buttonTextColor : '#ffffff',
+							backgroundColor: buttonBackgroundColor ? buttonBackgroundColor : '#3373dc'
 						} }
 					>
 						<RichText.Content

--- a/src/blocks/block-button/index.js
+++ b/src/blocks/block-button/index.js
@@ -129,10 +129,10 @@ registerBlockType( 'atomic-blocks/ab-button', {
 			type: 'string'
 		},
 		buttonBackgroundColor: {
-			type: 'string',
+			type: 'string'
 		},
 		buttonTextColor: {
-			type: 'string',
+			type: 'string'
 		},
 		buttonSize: {
 			type: 'string',


### PR DESCRIPTION
**Summary of change:**
Allow users to clear color values without breaking the block. I've removed the default values from the attributes and added them inline instead. 

**How to test:**

1. Check out master, create a button with the default or custom color, save the page.
2. Check out issue/246 and reload the page.
3. Clear the color on the button, save the page, and reload. 
4. You should see the block without any invalid content warnings.

<!-- If this PR fully resolves an existing issue, link it here. -->
**Fixes:** #246 
**Fixes:** #237 

**Suggested Changelog Entry:**
Fix invalid content warning after clearing button background color.