### PR TITLE
Whitelist HTML block in pricing table

### DIFF
--- a/src/blocks/block-pricing-table-inner/index.js
+++ b/src/blocks/block-pricing-table-inner/index.js
@@ -23,8 +23,7 @@ const { registerBlockType } = wp.blocks;
 const {
 	InnerBlocks,
 	AlignmentToolbar,
-	BlockControls,
-	BlockAlignmentToolbar
+	BlockControls
 } = wp.editor;
 
 const {
@@ -38,7 +37,8 @@ const ALLOWED_BLOCKS = [
 	'atomic-blocks/ab-pricing-table-title',
 	'atomic-blocks/ab-pricing-table-button',
 	'core/paragraph',
-	'core/image'
+	'core/image',
+	'core/html'
 ];
 
 class ABPricingTableBlock extends Component {
@@ -54,8 +54,6 @@ class ABPricingTableBlock extends Component {
 			padding,
 			alignment
 		},
-			isSelected,
-			className,
 			setAttributes
 		} = this.props;
 

--- a/src/blocks/block-pricing-table/components/inspector.js
+++ b/src/blocks/block-pricing-table/components/inspector.js
@@ -13,10 +13,7 @@ const {
 
 // Import Inspector components
 const {
-	Toolbar,
-	Button,
 	PanelBody,
-	PanelRow,
 	RangeControl
 } = wp.components;
 
@@ -36,10 +33,7 @@ export default class Inspector extends Component {
 			attributes: {
 				columns,
 				columnsGap
-			},
-			isSelected,
-			className,
-			setAttributes
+			}
 		} = this.props;
 
 		return (

--- a/src/blocks/block-pricing-table/components/pricing.js
+++ b/src/blocks/block-pricing-table/components/pricing.js
@@ -23,7 +23,6 @@ export default class Pricing extends Component {
 		const {
 			attributes: {
 				columns,
-				columnsGap,
 				align
 			}
 		} = this.props;

--- a/src/blocks/block-pricing-table/index.js
+++ b/src/blocks/block-pricing-table/index.js
@@ -20,19 +20,10 @@ const { registerBlockType } = wp.blocks;
 
 // Register editor components
 const {
-	RichText,
-	AlignmentToolbar,
 	BlockControls,
 	BlockAlignmentToolbar,
-	MediaUpload,
 	InnerBlocks
 } = wp.editor;
-
-// Register components
-const {
-	Button,
-	SelectControl
-} = wp.components;
 
 // Set allowed blocks and media
 const ALLOWED_BLOCKS = [ 'atomic-blocks/ab-pricing-table' ];
@@ -53,10 +44,6 @@ class ABPricingBlock extends Component {
 				columnsGap,
 				align
 			},
-			attributes,
-			isSelected,
-			editable,
-			className,
 			setAttributes
 		} = this.props;
 
@@ -135,9 +122,7 @@ registerBlockType( 'atomic-blocks/ab-pricing', {
 
 		// Setup the attributes
 		const {
-			columns,
-			columnsGap,
-			align
+			columnsGap
 		} = props.attributes;
 
 		// Setup the classes


### PR DESCRIPTION
**Summary of change:**
Add HTML block to blocks allowed in the pricing table.

**How to test:**

1. Add a pricing table block to the page.
2. Try to add the custom HTML block to the pricing table.

<!-- If this PR fully resolves an existing issue, link it here. -->
**Fixes:** #274 

**Suggested Changelog Entry:**
Add HTML block to blocks allowed in the pricing table.