### PR TITLE
Fix null value warning accordion

### DIFF
--- a/src/blocks/block-accordion/index.js
+++ b/src/blocks/block-accordion/index.js
@@ -38,7 +38,7 @@ const blockAttributes = {
 	},
 	accordionFontSize: {
 		type: 'number',
-		default: null
+		default: undefined
 	},
 	accordionOpen: {
 		type: 'boolean',


### PR DESCRIPTION
**Summary of change:**
Switch `null` definition to `undefined` to avoid null value warning in React.

**How to test:**
Check out this branch, add the accordion, check the inspector to see that there is no warning.

<!-- If this PR fully resolves an existing issue, link it here. -->
**Fixes:** #265

**Suggested Changelog Entry:**
Fix null value warning accordion