### PR TITLE
Allow removal of max width on container

### DIFF
--- a/src/blocks/block-container/deprecated/2.3.0/components/container.js
+++ b/src/blocks/block-container/deprecated/2.3.0/components/container.js
@@ -11,7 +11,7 @@ import classnames from 'classnames';
 /**
  * Create a Button wrapper Component
  */
-export default class Container extends Component {
+export default class Container_2_3_0 extends Component {
 
 	constructor( props ) {
 		super( ...arguments );
@@ -81,7 +81,7 @@ export default class Container extends Component {
 					<div
 						className="ab-container-content"
 						style={ {
-							maxWidth: containerMaxWidth ? `${containerMaxWidth}px` : undefined
+							maxWidth: `${containerMaxWidth}px`
 						} }
 					>
 						{ this.props.children }

--- a/src/blocks/block-container/deprecated/deprecated.js
+++ b/src/blocks/block-container/deprecated/deprecated.js
@@ -184,7 +184,8 @@ const deprecated = [
 	{
 		attributes: Container_2_3_0_attr,
         save: Container_2_3_0_save
-    },
+	},
+
     // Version 1_4_23
 	{
 		attributes: Container_1_4_23_attr,

--- a/src/blocks/block-container/deprecated/deprecated.js
+++ b/src/blocks/block-container/deprecated/deprecated.js
@@ -1,10 +1,62 @@
 import classnames from 'classnames';
 import Container_1_4_23 from './1.4.23/components/container';
+import Container_2_3_0 from './2.3.0/components/container';
 
 const {
-	RichText,
 	InnerBlocks
 } = wp.editor;
+
+// Version 2_3_0 attributes
+
+export const Container_2_3_0_attr = {
+	containerPaddingTop: {
+		type: 'number'
+	},
+	containerPaddingRight: {
+		type: 'number'
+	},
+	containerPaddingBottom: {
+		type: 'number'
+	},
+	containerPaddingLeft: {
+		type: 'number'
+	},
+	containerMarginTop: {
+		type: 'number'
+	},
+	containerMarginBottom: {
+		type: 'number'
+	},
+	containerWidth: {
+		type: 'string'
+	},
+	containerMaxWidth: {
+		type: 'number',
+		default: 1600
+	},
+	containerBackgroundColor: {
+		type: 'string'
+	},
+	containerImgURL: {
+		type: 'string',
+		source: 'attribute',
+		attribute: 'src',
+		selector: 'img'
+	},
+	containerImgID: {
+		type: 'number'
+	},
+	containerImgAlt: {
+		type: 'string',
+		source: 'attribute',
+		attribute: 'alt',
+		selector: 'img'
+	},
+	containerDimRatio: {
+		type: 'number',
+		default: 50
+	}
+};
 
 // Version 1_4_22 attributes
 
@@ -66,21 +118,22 @@ export const Container_1_4_23_attr = {
 	}
 };
 
+// Version 2_3_0 save
+
+export const Container_2_3_0_save = props => {
+	return (
+		<Container_2_3_0 { ...props }>
+            <InnerBlocks.Content />
+        </Container_2_3_0>
+	);
+};
+
 // Version 1_4_22 save
 
 export const Container_1_4_23_save = props => {
 	const {
-		containerPaddingTop,
-		containerPaddingRight,
-		containerPaddingBottom,
-		containerPaddingLeft,
-		containerMarginTop,
-		containerMarginBottom,
-		containerWidth,
 		containerMaxWidth,
-		containerBackgroundColor,
 		containerImgURL,
-		containerImgID,
 		containerImgAlt,
 		containerDimRatio
 	} = props.attributes;
@@ -127,6 +180,11 @@ function dimRatioToClass( ratio ) {
 
 const deprecated = [
 
+	// Version 2_3_0
+	{
+		attributes: Container_2_3_0_attr,
+        save: Container_2_3_0_save
+    },
     // Version 1_4_23
 	{
 		attributes: Container_1_4_23_attr,

--- a/src/blocks/block-container/index.js
+++ b/src/blocks/block-container/index.js
@@ -3,7 +3,6 @@
  */
 
 // Import block dependencies and components
-import classnames from 'classnames';
 import Inspector from './components/inspector';
 import Container from './components/container';
 
@@ -87,10 +86,6 @@ class ABContainerBlock extends Component {
 		const {
 			attributes: {
 				containerWidth,
-				containerMaxWidth,
-				containerImgURL,
-				containerImgAlt,
-				containerDimRatio
 			},
 			setAttributes
 		} = this.props;
@@ -113,32 +108,7 @@ class ABContainerBlock extends Component {
 
 			// Show the container markup in the editor
 			<Container { ...this.props }>
-				<div className="ab-container-inside">
-					{ containerImgURL && !! containerImgURL.length && (
-						<div className="ab-container-image-wrap">
-							<img
-								className={ classnames(
-									'ab-container-image',
-									dimRatioToClass( containerDimRatio ),
-									{
-										'has-background-dim': 0 !== containerDimRatio
-									}
-								) }
-								src={ containerImgURL }
-								alt={ containerImgAlt }
-							/>
-						</div>
-					) }
-
-					<div
-						className="ab-container-content"
-						style={ {
-							maxWidth: containerMaxWidth ? `${containerMaxWidth}px` : undefined
-						} }
-					>
-						<InnerBlocks />
-					</div>
-				</div>
+				<InnerBlocks />
 			</Container>
 		];
 	}
@@ -170,43 +140,10 @@ registerBlockType( 'atomic-blocks/ab-container', {
 	// Save the attributes and markup
 	save: function( props ) {
 
-		// Setup the attributes
-		const {
-			containerMaxWidth,
-			containerImgURL,
-			containerImgAlt,
-			containerDimRatio
-		} = props.attributes;
-
 		// Save the block markup for the front end
 		return (
 			<Container { ...props }>
-				<div className="ab-container-inside">
-					{ containerImgURL && !! containerImgURL.length && (
-						<div className="ab-container-image-wrap">
-							<img
-								className={ classnames(
-									'ab-container-image',
-									dimRatioToClass( containerDimRatio ),
-									{
-										'has-background-dim': 0 !== containerDimRatio
-									}
-								) }
-								src={ containerImgURL }
-								alt={ containerImgAlt }
-							/>
-						</div>
-					) }
-
-					<div
-						className="ab-container-content"
-						style={ {
-							maxWidth: containerMaxWidth ? `${containerMaxWidth}px` : undefined
-						} }
-					>
-						<InnerBlocks.Content />
-					</div>
-				</div>
+				<InnerBlocks.Content />
 			</Container>
 		);
 	},
@@ -214,15 +151,3 @@ registerBlockType( 'atomic-blocks/ab-container', {
 	deprecated: deprecated
 
 });
-
-function dimRatioToClass( ratio ) {
-	return ( 0 === ratio || 50 === ratio ) ?
-		null :
-		'has-background-dim-' + ( 10 * Math.round( ratio / 10 ) );
-}
-
-function backgroundImageStyles( url ) {
-	return url ?
-		{ backgroundImage: `url(${ url })` } :
-		undefined;
-}

--- a/src/blocks/block-container/index.js
+++ b/src/blocks/block-container/index.js
@@ -85,7 +85,7 @@ class ABContainerBlock extends Component {
 		// Setup the attributes
 		const {
 			attributes: {
-				containerWidth,
+				containerWidth
 			},
 			setAttributes
 		} = this.props;

--- a/src/blocks/block-container/index.js
+++ b/src/blocks/block-container/index.js
@@ -53,8 +53,7 @@ const blockAttributes = {
 		type: 'string'
 	},
 	containerMaxWidth: {
-		type: 'number',
-		default: 1600
+		type: 'number'
 	},
 	containerBackgroundColor: {
 		type: 'string'
@@ -134,7 +133,7 @@ class ABContainerBlock extends Component {
 					<div
 						className="ab-container-content"
 						style={ {
-							maxWidth: `${containerMaxWidth}px`
+							maxWidth: containerMaxWidth ? `${containerMaxWidth}px` : undefined
 						} }
 					>
 						<InnerBlocks />
@@ -202,7 +201,7 @@ registerBlockType( 'atomic-blocks/ab-container', {
 					<div
 						className="ab-container-content"
 						style={ {
-							maxWidth: `${containerMaxWidth}px`
+							maxWidth: containerMaxWidth ? `${containerMaxWidth}px` : undefined
 						} }
 					>
 						<InnerBlocks.Content />

--- a/src/blocks/block-container/index.js
+++ b/src/blocks/block-container/index.js
@@ -25,23 +25,10 @@ const { registerBlockType } = wp.blocks;
 
 // Register editor components
 const {
-	AlignmentToolbar,
 	BlockControls,
 	BlockAlignmentToolbar,
-	MediaUpload,
-	RichText,
 	InnerBlocks
 } = wp.editor;
-
-// Register components
-const {
-	Button,
-	withFallbackStyles,
-	IconButton,
-	Dashicon,
-	withState,
-	Toolbar
-} = wp.components;
 
 const blockAttributes = {
 	containerPaddingTop: {
@@ -100,34 +87,14 @@ class ABContainerBlock extends Component {
 		// Setup the attributes
 		const {
 			attributes: {
-				containerPaddingTop,
-				containerPaddingRight,
-				containerPaddingBottom,
-				containerPaddingLeft,
-				containerMarginTop,
-				containerMarginBottom,
 				containerWidth,
 				containerMaxWidth,
-				containerBackgroundColor,
 				containerImgURL,
-				containerImgID,
 				containerImgAlt,
 				containerDimRatio
 			},
-			attributes,
-			isSelected,
-			editable,
-			className,
 			setAttributes
 		} = this.props;
-
-		const onSelectImage = img => {
-			setAttributes({
-				containerImgID: img.id,
-				containerImgURL: img.url,
-				containerImgAlt: img.alt
-			});
-		};
 
 		return [
 
@@ -206,17 +173,8 @@ registerBlockType( 'atomic-blocks/ab-container', {
 
 		// Setup the attributes
 		const {
-			containerPaddingTop,
-			containerPaddingRight,
-			containerPaddingBottom,
-			containerPaddingLeft,
-			containerMarginTop,
-			containerMarginBottom,
-			containerWidth,
 			containerMaxWidth,
-			containerBackgroundColor,
 			containerImgURL,
-			containerImgID,
 			containerImgAlt,
 			containerDimRatio
 		} = props.attributes;


### PR DESCRIPTION
**Summary of change:**
Remove the default max width attribute and allow users to clear the max width. This change required a block deprecation, so please test accordingly.

**How to test:**

1. Check out master, add a container block and ensure a max width is set and save the page.
2. Check out `issue/231`, rebuild assets, and then refresh the page. No error should show after refreshing.
3. Remove the max width by clearing the value out of the slider and save the block again.
4. Reload the page and ensure there is no error on the block.
5. Try a few different max width scenarios in the `issue/231` branch. 

<!-- If this PR fully resolves an existing issue, link it here. -->
**Fixes:** #231 

**Suggested Changelog Entry:**
Allow removal of max width value on Container block.