### PR TITLE
Add missing IE prefixes for CSS Grid

### DIFF
--- a/src/blocks/block-column-inner/styles/editor.scss
+++ b/src/blocks/block-column-inner/styles/editor.scss
@@ -18,7 +18,9 @@
 }
 
 .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+	display: -ms-grid;
 	display: grid;
+	-ms-grid-rows: 1fr;
     grid-template-rows: 1fr;
     grid-gap: 0 2em;
     min-height: 0;
@@ -113,6 +115,7 @@
 /* One column grid. */
 
 .ab-layout-columns-1 > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+	-ms-grid-columns: 1fr;
 	grid-template-columns: 1fr;
 	grid-template-areas: "col1";
 }
@@ -120,60 +123,72 @@
 /* Two column grid. */
 
 .ab-layout-columns-2 > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+	-ms-grid-columns: 1fr 1fr;
 	grid-template-columns: 1fr 1fr;
 	grid-template-areas: "col1 col2";
 }
 
 .ab-2-col-wideleft > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+	-ms-grid-columns: 2fr 1fr;
 	grid-template-columns: 2fr 1fr;
 }
 
 .ab-2-col-wideright > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+	-ms-grid-columns: 1fr 2fr;
 	grid-template-columns: 1fr 2fr;
 }
 
 /* Three column grid. */
 
 .ab-layout-columns-3 > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+	-ms-grid-columns: 1fr 1fr 1fr;
 	grid-template-columns: 1fr 1fr 1fr;
 	grid-template-areas: "col1 col2 col3";
 }
 
 .ab-3-col-widecenter > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+	-ms-grid-columns: 1fr 2fr 1fr;
 	grid-template-columns: 1fr 2fr 1fr;
 }
 
 .ab-3-col-wideleft > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+	-ms-grid-columns: 2fr 1fr 1fr;
 	grid-template-columns: 2fr 1fr 1fr;
 }
 
 .ab-3-col-wideright > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+	-ms-grid-columns: 1fr 1fr 2fr;
 	grid-template-columns: 1fr 1fr 2fr;
 }
 
 /* Four column grid. */
 
 .ab-layout-columns-4 > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+	-ms-grid-columns: 1fr 1fr 1fr 1fr;
 	grid-template-columns: 1fr 1fr 1fr 1fr;
 	grid-template-areas: "col1 col2 col3 col4";
 }
 
 .ab-4-col-wideleft > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+	-ms-grid-columns: 2fr 1fr 1fr 1fr;
 	grid-template-columns: 2fr 1fr 1fr 1fr;
 }
 
 .ab-4-col-wideright > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+	-ms-grid-columns: 1fr 1fr 1fr 2fr;
 	grid-template-columns: 1fr 1fr 1fr 2fr;
 }
 
 /* Five column grid. */
 
 .ab-layout-columns-5 > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+	-ms-grid-columns: 1fr 1fr 1fr 1fr 1fr;
 	grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
 	grid-template-areas: "col1 col2 col3 col4 col5";
 }
 
 .ab-layout-columns-6 > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+	-ms-grid-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
 	grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
 	grid-template-areas: "col1 col2 col3 col4 col5 col6";
 }

--- a/src/blocks/block-column-inner/styles/style.scss
+++ b/src/blocks/block-column-inner/styles/style.scss
@@ -160,6 +160,7 @@
 /* One column grid. */
 
 .ab-layout-columns-1 > .ab-layout-column-wrap {
+	-ms-grid-columns: 1fr;
 	grid-template-columns: 1fr;
 	grid-template-areas: "col1";
 }
@@ -167,11 +168,13 @@
 /* Two column grid. */
 
 .ab-layout-columns-2 > .ab-layout-column-wrap {
+	-ms-grid-columns: 1fr 1fr;
 	grid-template-columns: 1fr 1fr;
 	grid-template-areas: "col1 col2";
 
 	&.ab-is-responsive-column {
 		@media only screen and (max-width: 600px) {
+			-ms-grid-columns: 1fr;
 			grid-template-columns: 1fr;
 			grid-template-areas:
 			"col1"
@@ -181,21 +184,25 @@
 }
 
 .ab-2-col-wideleft > .ab-layout-column-wrap {
+	-ms-grid-columns: 2fr 1fr;
 	grid-template-columns: 2fr 1fr;
 }
 
 .ab-2-col-wideright > .ab-layout-column-wrap {
+	-ms-grid-columns: 1fr 2fr;
 	grid-template-columns: 1fr 2fr;
 }
 
 /* Three column grid. */
 
 .ab-layout-columns-3 > .ab-layout-column-wrap {
+	-ms-grid-columns: 1fr 1fr 1fr;
 	grid-template-columns: 1fr 1fr 1fr;
 	grid-template-areas: "col1 col2 col3";
 
 	&.ab-is-responsive-column {
 		@media only screen and (max-width: 600px) {
+			-ms-grid-columns: 1fr;
 			grid-template-columns: 1fr;
 			grid-template-areas:
 			"col1"
@@ -206,30 +213,36 @@
 }
 
 .ab-3-col-widecenter > .ab-layout-column-wrap {
+	-ms-grid-columns: 1fr 2fr 1fr;
 	grid-template-columns: 1fr 2fr 1fr;
 
 	&.ab-is-responsive-column {
 		@media only screen and (max-width: 600px) {
+			-ms-grid-columns: 1fr;
 			grid-template-columns: 1fr;
 		}
 	}
 }
 
 .ab-3-col-wideleft > .ab-layout-column-wrap {
+	-ms-grid-columns: 2fr 1fr 1fr;
 	grid-template-columns: 2fr 1fr 1fr;
 
 	&.ab-is-responsive-column {
 		@media only screen and (max-width: 600px) {
+			-ms-grid-columns: 1fr;
 			grid-template-columns: 1fr;
 		}
 	}
 }
 
 .ab-3-col-wideright > .ab-layout-column-wrap {
+	-ms-grid-columns: 1fr 1fr 2fr;
 	grid-template-columns: 1fr 1fr 2fr;
 
 	&.ab-is-responsive-column {
 		@media only screen and (max-width: 600px) {
+			-ms-grid-columns: 1fr;
 			grid-template-columns: 1fr;
 		}
 	}
@@ -238,12 +251,14 @@
 /* Four column grid. */
 
 .ab-layout-columns-4 > .ab-layout-column-wrap {
+	-ms-grid-columns: 1fr 1fr 1fr 1fr;
 	grid-template-columns: 1fr 1fr 1fr 1fr;
 	grid-template-areas: "col1 col2 col3 col4";
 
 	&.ab-is-responsive-column {
 		@media only screen and (max-width: 800px) {
 			grid-template-rows: auto;
+			-ms-grid-columns: 1fr 1fr;
 			grid-template-columns: 1fr 1fr;
 			grid-template-areas:
 			"col1 col2"
@@ -251,6 +266,7 @@
 		}
 
 		@media only screen and (max-width: 600px) {
+			-ms-grid-columns: 1fr;
 			grid-template-columns: 1fr;
 			grid-template-areas:
 			"col1"
@@ -262,21 +278,25 @@
 }
 
 .ab-4-col-wideleft > .ab-layout-column-wrap {
+	-ms-grid-columns: 2fr 1fr 1fr 1fr;
 	grid-template-columns: 2fr 1fr 1fr 1fr;
 }
 
 .ab-4-col-wideright > .ab-layout-column-wrap {
+	-ms-grid-columns: 1fr 1fr 1fr 2fr;
 	grid-template-columns: 1fr 1fr 1fr 2fr;
 }
 
 /* Five column grid. */
 
 .ab-layout-columns-5 > .ab-layout-column-wrap {
+	-ms-grid-columns: 1fr 1fr 1fr 1fr 1fr;
 	grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
 	grid-template-areas: "col1 col2 col3 col4 col5";
 
 	&.ab-is-responsive-column {
 		@media only screen and (max-width: 800px) {
+			-ms-grid-columns: 1fr;
 			grid-template-columns: 1fr;
 			grid-template-areas:
 			"col1"
@@ -289,11 +309,13 @@
 }
 
 .ab-layout-columns-6 > .ab-layout-column-wrap {
+	-ms-grid-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
 	grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
 	grid-template-areas: "col1 col2 col3 col4 col5 col6";
 
 	&.ab-is-responsive-column {
 		@media only screen and (max-width: 800px) {
+			-ms-grid-columns: 1fr 1fr;
 			grid-template-columns: 1fr 1fr;
 			grid-template-areas:
 			"col1 col2"
@@ -302,6 +324,7 @@
 		}
 
 		@media only screen and (max-width: 600px) {
+			-ms-grid-columns: 1fr;
 			grid-template-columns: 1fr;
 			grid-template-areas:
 			"col1"

--- a/src/blocks/block-layout/styles/editor.scss
+++ b/src/blocks/block-layout/styles/editor.scss
@@ -67,7 +67,9 @@
 		background: #f2f2f2;
 		padding: 20px;
 		margin-bottom: 20px;
+		display: -ms-grid;
 		display: grid;
+		-ms-grid-columns: 1fr 1fr;
 		grid-template-columns: 1fr 1fr;
 		grid-template-rows: 1fr;
 		grid-gap: 0 5em;
@@ -90,18 +92,23 @@
 	}
 
 	.ab-layout-choices {
+		display: -ms-grid;
 		display: grid;
+		-ms-grid-columns: 1fr 1fr;
 		grid-template-columns: 1fr 1fr;
 		grid-template-rows: 1fr;
 		grid-gap: 0 2em;
 	}
 
 	.ab-layout-view-full {
+		-ms-grid-columns: 1fr;
 		grid-template-columns: 1fr;
 	}
 
 	.ab-layout-view {
+		display: -ms-grid;
 		display: grid;
+		-ms-grid-columns: 1fr 1fr;
 		grid-template-columns: 1fr 1fr;
 		grid-template-rows: 1fr;
 		grid-gap: 0 2em;

--- a/src/blocks/block-post-grid/styles/style.scss
+++ b/src/blocks/block-post-grid/styles/style.scss
@@ -8,7 +8,9 @@
 	position: relative;
 
 	.is-grid {
+		display: -ms-grid;
 		display: grid;
+		-ms-grid-columns: 1fr 1fr;
 		grid-template-columns: 1fr 1fr;
 		grid-template-rows: 1fr;
 		grid-gap: 0 2em;
@@ -31,6 +33,7 @@
 	}
 
 	.is-grid.columns-1 {
+		-ms-grid-columns: 1fr;
 		grid-template-columns: 1fr;
 
 		@media all and (-ms-high-contrast:none) {
@@ -41,6 +44,7 @@
 	}
 
 	.is-grid.columns-2 {
+		-ms-grid-columns: 1fr 1fr;
 		grid-template-columns: 1fr 1fr;
 
 		@media all and (-ms-high-contrast:none) {
@@ -51,6 +55,7 @@
 	}
 
 	.is-grid.columns-3 {
+		-ms-grid-columns: 1fr 1fr 1fr;
 		grid-template-columns: 1fr 1fr 1fr;
 
 		@media all and (-ms-high-contrast:none) {
@@ -61,6 +66,7 @@
 	}
 
 	.is-grid.columns-4 {
+		-ms-grid-columns: 1fr 1fr 1fr 1fr;
 		grid-template-columns: 1fr 1fr 1fr 1fr;
 
 		@media all and (-ms-high-contrast:none) {
@@ -72,6 +78,7 @@
 
 	div[class*="columns"].is-grid {
 		@media only screen and (max-width: 600px) {
+			-ms-grid-columns: 1fr;
 			grid-template-columns: 1fr;
 		}
 	}
@@ -170,7 +177,9 @@
 
 	.is-list {
 		article {
+			display: -ms-grid;
 			display: grid;
+			-ms-grid-columns: 30% 1fr;
 			grid-template-columns: 30% 1fr;
 			grid-template-rows: 1fr;
 			grid-gap: 0 2em;
@@ -195,11 +204,13 @@
 			}
 
 			@media only screen and (max-width: 600px) {
+				-ms-grid-columns: 1fr;
 				grid-template-columns: 1fr;
 			}
 		}
 
 		article:not(.has-post-thumbnail) {
+			-ms-grid-columns: 1fr;
 			grid-template-columns: 1fr;
 		}
 

--- a/src/blocks/block-pricing-table-inner/styles/editor.scss
+++ b/src/blocks/block-pricing-table-inner/styles/editor.scss
@@ -8,6 +8,7 @@
 }
 
 .ab-pricing-table-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+	display: -ms-grid;
 	display: grid;
     grid-template-rows: 1fr;
     grid-gap: 0 2em;
@@ -43,41 +44,51 @@
 /* Grid column classes */
 
 .ab-pricing-columns-2 .editor-block-list__layout {
-    grid-template-columns: 1fr 1fr;
+	-ms-grid-columns: 1fr 1fr;
+	grid-template-columns: 1fr 1fr;
 
     @media only screen and (max-width: 600px) {
-        grid-template-columns: 1fr;
+		-ms-grid-columns: 1fr;
+		grid-template-columns: 1fr;
     }
 }
 
 .ab-pricing-columns-3 .editor-block-list__layout {
+	-ms-grid-columns: 1fr 1fr 1fr;
 	grid-template-columns: 1fr 1fr 1fr;
 
 	@media only screen and (max-width: 600px) {
+		-ms-grid-columns: 1fr;
 		grid-template-columns: 1fr;
 	}
 }
 
 .ab-pricing-columns-4 .editor-block-list__layout {
+	-ms-grid-columns: 1fr 1fr 1fr 1fr;
 	grid-template-columns: 1fr 1fr 1fr 1fr;
 
 	@media only screen and (max-width: 800px) {
+		-ms-grid-columns: 1fr 1fr;
 		grid-template-columns: 1fr 1fr;
 	}
 
 	@media only screen and (max-width: 600px) {
+		-ms-grid-columns: 1fr;
 		grid-template-columns: 1fr;
 	}
 }
 
 .ab-pricing-columns-5 .editor-block-list__layout {
+	-ms-grid-columns: 1fr 1fr 1fr 1fr 1fr;
 	grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
 
 	@media only screen and (max-width: 800px) {
+		-ms-grid-columns: 1fr 1fr;
 		grid-template-columns: 1fr 1fr;
 	}
 
 	@media only screen and (max-width: 600px) {
+		-ms-grid-columns: 1fr;
 		grid-template-columns: 1fr;
 	}
 }

--- a/src/blocks/block-pricing-table-inner/styles/style.scss
+++ b/src/blocks/block-pricing-table-inner/styles/style.scss
@@ -8,6 +8,7 @@
 }
 
 .ab-pricing-table-wrap {
+	display: -ms-grid;
 	display: grid;
 	grid-template-rows: 1fr;
 	grid-template-areas: "col1";
@@ -67,10 +68,12 @@
 /* Grid column classes */
 
 .ab-pricing-columns-2 .ab-pricing-table-wrap {
+	-ms-grid-columns: 1fr 1fr;
 	grid-template-columns: 1fr 1fr;
 	grid-template-areas: "col1 col2";
 
 	@media only screen and (max-width: 600px) {
+		-ms-grid-columns: 1fr;
 		grid-template-columns: 1fr;
 		grid-template-areas:
 		"col1"
@@ -79,10 +82,12 @@
 }
 
 .ab-pricing-columns-3 .ab-pricing-table-wrap {
+	-ms-grid-columns: 1fr 1fr 1fr;
 	grid-template-columns: 1fr 1fr 1fr;
 	grid-template-areas: "col1 col2 col3";
 
 	@media only screen and (max-width: 600px) {
+		-ms-grid-columns: 1fr;
 		grid-template-columns: 1fr;
 		grid-template-areas:
 			"col1"
@@ -92,10 +97,12 @@
 }
 
 .ab-pricing-columns-4 .ab-pricing-table-wrap {
+	-ms-grid-columns: 1fr 1fr 1fr 1fr;
 	grid-template-columns: 1fr 1fr 1fr 1fr;
 	grid-template-areas: "col1 col2 col3 col4";
 
 	@media only screen and (max-width: 800px) {
+		-ms-grid-columns: 1fr 1fr;
 		grid-template-columns: 1fr 1fr;
 		grid-template-areas:
 			"col1 col2"
@@ -107,6 +114,7 @@
 	}
 
 	@media only screen and (max-width: 600px) {
+		-ms-grid-columns: 1fr;
 		grid-template-columns: 1fr;
 		grid-template-areas:
 			"col1"


### PR DESCRIPTION
**Summary of change:**
Add missing IE11 prefixes for CSS Grid in Columns block.

**How to test:**
Create a few different column layouts and visit them in IE11. Columns should behave as expected.

<!-- If this PR fully resolves an existing issue, link it here. -->
**Fixes:** #257 

**Suggested Changelog Entry:**
Improve CSS Grid styles for Advanced Column block in IE11.