### PR TITLE
Change wp.editor reference to wp.blockEditor

### DIFF
--- a/src/blocks/block-accordion/components/edit.js
+++ b/src/blocks/block-accordion/components/edit.js
@@ -14,7 +14,7 @@ const {
 	AlignmentToolbar,
 	BlockControls,
 	InnerBlocks
-} = wp.editor;
+} = wp.blockEditor;
 
 export default class Edit extends Component {
 	constructor() {

--- a/src/blocks/block-accordion/components/inspector.js
+++ b/src/blocks/block-accordion/components/inspector.js
@@ -18,7 +18,7 @@ const { Component } = wp.element;
  */
 const {
   InspectorControls
-} = wp.editor;
+} = wp.blockEditor;
 
 /**
  * Import Inspector components.

--- a/src/blocks/block-accordion/components/save.js
+++ b/src/blocks/block-accordion/components/save.js
@@ -8,7 +8,7 @@ const { Component } = wp.element;
 const {
 	RichText,
 	InnerBlocks
-} = wp.editor;
+} = wp.blockEditor;
 
 export default class Save extends Component {
 	constructor() {

--- a/src/blocks/block-accordion/deprecated/2.0/components/save.js
+++ b/src/blocks/block-accordion/deprecated/2.0/components/save.js
@@ -8,7 +8,7 @@ const { Component } = wp.element;
 const {
 	RichText,
 	InnerBlocks
-} = wp.editor;
+} = wp.blockEditor;
 
 export default class Save_2_0 extends Component {
 	constructor() {

--- a/src/blocks/block-author-profile/components/edit.js
+++ b/src/blocks/block-author-profile/components/edit.js
@@ -23,7 +23,7 @@ const {
 	AlignmentToolbar,
 	BlockControls,
 	MediaUpload
-} = wp.editor;
+} = wp.blockEditor;
 
 const { Button, Dashicon } = wp.components;
 

--- a/src/blocks/block-author-profile/components/inspector.js
+++ b/src/blocks/block-author-profile/components/inspector.js
@@ -15,7 +15,7 @@ const { Component } = wp.element;
 const {
 	InspectorControls,
 	PanelColorSettings
-} = wp.editor;
+} = wp.blockEditor;
 
 /* Import Inspector components. */
 const {

--- a/src/blocks/block-author-profile/components/save.js
+++ b/src/blocks/block-author-profile/components/save.js
@@ -12,7 +12,7 @@ import AvatarColumn from './avatar';
 const { Component } = wp.element;
 const {
 	RichText
-} = wp.editor;
+} = wp.blockEditor;
 
 export default class Save extends Component {
 	constructor() {

--- a/src/blocks/block-author-profile/deprecated/1.8.1/components/save.js
+++ b/src/blocks/block-author-profile/deprecated/1.8.1/components/save.js
@@ -12,7 +12,7 @@ import AvatarColumn from '../../../components/avatar';
 const { Component } = wp.element;
 const {
 	RichText
-} = wp.editor;
+} = wp.blockEditor;
 
 export default class Save_1_8_1 extends Component {
 	constructor() {

--- a/src/blocks/block-button/components/inspector.js
+++ b/src/blocks/block-button/components/inspector.js
@@ -12,7 +12,7 @@ const { Component } = wp.element;
 // Import block components
 const {
   InspectorControls
-} = wp.editor;
+} = wp.blockEditor;
 
 // Import Inspector components
 const {

--- a/src/blocks/block-button/index.js
+++ b/src/blocks/block-button/index.js
@@ -26,7 +26,7 @@ const {
 	AlignmentToolbar,
 	BlockControls,
 	URLInput
-} = wp.editor;
+} = wp.blockEditor;
 
 // Register components
 const {

--- a/src/blocks/block-column-inner/components/edit.js
+++ b/src/blocks/block-column-inner/components/edit.js
@@ -17,7 +17,7 @@ const {
 	BlockControls,
 	InnerBlocks,
 	withColors
-} = wp.editor;
+} = wp.blockEditor;
 
 class Edit extends Component {
 

--- a/src/blocks/block-column-inner/components/inspector.js
+++ b/src/blocks/block-column-inner/components/inspector.js
@@ -17,7 +17,7 @@ const {
 	PanelColorSettings,
 	withColors,
 	ContrastChecker
-} = wp.editor;
+} = wp.blockEditor;
 const {
 	PanelBody,
 	ToggleControl,

--- a/src/blocks/block-column-inner/components/save.js
+++ b/src/blocks/block-column-inner/components/save.js
@@ -7,7 +7,7 @@ import Column from './column';
  * WordPress dependencies.
  */
 const { Component } = wp.element;
-const { InnerBlocks } = wp.editor;
+const { InnerBlocks } = wp.blockEditor;
 
 export default class Save extends Component {
 

--- a/src/blocks/block-column-inner/deprecated/1.7.1/components/save.js
+++ b/src/blocks/block-column-inner/deprecated/1.7.1/components/save.js
@@ -7,7 +7,7 @@ import Column_1_7_1 from './column';
  * WordPress dependencies.
  */
 const { Component } = wp.element;
-const { InnerBlocks } = wp.editor;
+const { InnerBlocks } = wp.blockEditor;
 
 export default class Save_1_7_1 extends Component {
 

--- a/src/blocks/block-column/components/edit.js
+++ b/src/blocks/block-column/components/edit.js
@@ -21,7 +21,7 @@ const {
 	BlockAlignmentToolbar,
 	InnerBlocks,
 	withColors
-} = wp.editor;
+} = wp.blockEditor;
 const {
 	Placeholder,
 	ButtonGroup,

--- a/src/blocks/block-column/components/inspector.js
+++ b/src/blocks/block-column/components/inspector.js
@@ -21,7 +21,7 @@ const {
 	InspectorControls,
 	PanelColorSettings,
 	ContrastChecker
-} = wp.editor;
+} = wp.blockEditor;
 const {
 	PanelBody,
 	RangeControl,

--- a/src/blocks/block-column/components/save.js
+++ b/src/blocks/block-column/components/save.js
@@ -8,7 +8,7 @@ import Columns from './column-wrap';
  * WordPress dependencies.
  */
 const { Component } = wp.element;
-const { InnerBlocks } = wp.editor;
+const { InnerBlocks } = wp.blockEditor;
 
 export default class Save extends Component {
 

--- a/src/blocks/block-container/components/inspector.js
+++ b/src/blocks/block-container/components/inspector.js
@@ -16,7 +16,7 @@ const {
   InspectorControls,
   PanelColorSettings,
   MediaUpload
-} = wp.editor;
+} = wp.blockEditor;
 
 // Import Inspector components
 const {

--- a/src/blocks/block-container/deprecated/deprecated.js
+++ b/src/blocks/block-container/deprecated/deprecated.js
@@ -4,7 +4,7 @@ import Container_2_3_0 from './2.3.0/components/container';
 
 const {
 	InnerBlocks
-} = wp.editor;
+} = wp.blockEditor;
 
 // Version 2_3_0 attributes
 

--- a/src/blocks/block-container/index.js
+++ b/src/blocks/block-container/index.js
@@ -27,7 +27,7 @@ const {
 	BlockControls,
 	BlockAlignmentToolbar,
 	InnerBlocks
-} = wp.editor;
+} = wp.blockEditor;
 
 const blockAttributes = {
 	containerPaddingTop: {

--- a/src/blocks/block-cta/components/inspector.js
+++ b/src/blocks/block-cta/components/inspector.js
@@ -16,7 +16,7 @@ const {
   InspectorControls,
   PanelColorSettings,
   MediaUpload
-} = wp.editor;
+} = wp.blockEditor;
 
 // Import Inspector components
 const {

--- a/src/blocks/block-cta/deprecated/deprecated.js
+++ b/src/blocks/block-cta/deprecated/deprecated.js
@@ -6,7 +6,7 @@ import CallToAction_1_4_21 from './1.4.21/components/cta';
 
 const {
 	RichText
-} = wp.editor;
+} = wp.blockEditor;
 
 export const callToAction_1_5_2_attr = {
 	buttonText: {

--- a/src/blocks/block-cta/index.js
+++ b/src/blocks/block-cta/index.js
@@ -30,7 +30,7 @@ const {
 	BlockControls,
 	BlockAlignmentToolbar,
 	RichText
-} = wp.editor;
+} = wp.blockEditor;
 
 // Register components
 const {

--- a/src/blocks/block-drop-cap/components/inspector.js
+++ b/src/blocks/block-drop-cap/components/inspector.js
@@ -14,7 +14,7 @@ const { Component } = wp.element;
 // Import block components
 const {
 	InspectorControls
-} = wp.editor;
+} = wp.blockEditor;
 
 // Import Inspector components
 const {

--- a/src/blocks/block-drop-cap/index.js
+++ b/src/blocks/block-drop-cap/index.js
@@ -25,7 +25,7 @@ const {
 	RichText,
 	AlignmentToolbar,
 	BlockControls
-} = wp.editor;
+} = wp.blockEditor;
 
 class ABDropCapBlock extends Component {
 

--- a/src/blocks/block-layout/components/edit.js
+++ b/src/blocks/block-layout/components/edit.js
@@ -17,7 +17,7 @@ const { Component, Fragment } = wp.element;
 const {
 	BlockControls,
 	BlockAlignmentToolbar
-} = wp.editor;
+} = wp.blockEditor;
 
 export default class Edit extends Component {
 

--- a/src/blocks/block-layout/components/layout/layout-library-item.js
+++ b/src/blocks/block-layout/components/layout/layout-library-item.js
@@ -50,7 +50,9 @@ export default compose(
 	 */
 	withSelect( ( select, { clientId }) => {
 		const {
-			getBlock,
+			getBlock
+		} = select( 'core/block-editor' );
+		const {
 			canUserUseUnfilteredHTML
 		} = select( 'core/editor' );
 		const block = getBlock( clientId );
@@ -60,7 +62,7 @@ export default compose(
 		};
 	}),
 	withDispatch( ( dispatch, { block, canUserUseUnfilteredHTML }) => ({
-		import: ( blockLayout ) => dispatch( 'core/editor' ).replaceBlocks(
+		import: ( blockLayout ) => dispatch( 'core/block-editor' ).replaceBlocks(
 			block.clientId,
 			rawHandler({
 				HTML: blockLayout,

--- a/src/blocks/block-layout/index.js
+++ b/src/blocks/block-layout/index.js
@@ -68,5 +68,5 @@ function appendImportButton() {
  */
 function abInsertLayout() {
 	let block = wp.blocks.createBlock( 'atomic-blocks/ab-layouts' );
-	wp.data.dispatch( 'core/editor' ).insertBlocks( block );
+	wp.data.dispatch( 'core/block-editor' ).insertBlocks( block );
 }

--- a/src/blocks/block-newsletter/components/edit.js
+++ b/src/blocks/block-newsletter/components/edit.js
@@ -22,7 +22,7 @@ const {
 	getColorClassName,
 	RichText,
 	withColors
-} = wp.editor;
+} = wp.blockEditor;
 const {
 	Fragment,
 	Component

--- a/src/blocks/block-newsletter/components/inspector.js
+++ b/src/blocks/block-newsletter/components/inspector.js
@@ -14,7 +14,7 @@ const {
 	withColors,
 	ContrastChecker,
 	PanelColorSettings
-} = wp.editor;
+} = wp.blockEditor;
 
 const { PanelBody,
 	SelectControl,

--- a/src/blocks/block-newsletter/components/newsletter.js
+++ b/src/blocks/block-newsletter/components/newsletter.js
@@ -6,7 +6,7 @@
  * WordPress dependencies
  */
 const { Component } = wp.element;
-const { getColorClassName } = wp.editor;
+const { getColorClassName } = wp.blockEditor;
 
 /**
  * External dependencies

--- a/src/blocks/block-notice/components/inspector.js
+++ b/src/blocks/block-notice/components/inspector.js
@@ -15,7 +15,7 @@ const { Component } = wp.element;
 const {
   PanelColorSettings,
   InspectorControls
-} = wp.editor;
+} = wp.blockEditor;
 
 // Import Inspector components
 const {

--- a/src/blocks/block-notice/index.js
+++ b/src/blocks/block-notice/index.js
@@ -27,7 +27,7 @@ const {
 	RichText,
 	AlignmentToolbar,
 	BlockControls
-} = wp.editor;
+} = wp.blockEditor;
 
 class ABNoticeBlock extends Component {
 

--- a/src/blocks/block-post-grid/components/edit.js
+++ b/src/blocks/block-post-grid/components/edit.js
@@ -30,7 +30,7 @@ const {
 const {
 	BlockAlignmentToolbar,
 	BlockControls
-} = wp.editor;
+} = wp.blockEditor;
 
 class LatestPostsBlock extends Component {
 

--- a/src/blocks/block-post-grid/components/inspector.js
+++ b/src/blocks/block-post-grid/components/inspector.js
@@ -13,7 +13,7 @@ import RenderSettingControl from '../../../utils/components/settings/renderSetti
 // Import block components
 const {
   InspectorControls
-} = wp.editor;
+} = wp.blockEditor;
 
 // Import Inspector components
 const {

--- a/src/blocks/block-pricing-table-inner/components/button/edit.js
+++ b/src/blocks/block-pricing-table-inner/components/button/edit.js
@@ -16,7 +16,7 @@ const {
 	withColors,
 	InnerBlocks,
 	URLInput
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
 	IconButton,

--- a/src/blocks/block-pricing-table-inner/components/button/index.js
+++ b/src/blocks/block-pricing-table-inner/components/button/index.js
@@ -17,7 +17,7 @@ const {
 	FontSizePicker,
 	withFontSizes,
 	getColorClassName
-} = wp.editor;
+} = wp.blockEditor;
 
 // Register the block
 registerBlockType( 'atomic-blocks/ab-pricing-table-button', {

--- a/src/blocks/block-pricing-table-inner/components/button/inspector.js
+++ b/src/blocks/block-pricing-table-inner/components/button/inspector.js
@@ -21,7 +21,7 @@ const {
 	withColors,
 	ContrastChecker,
 	PanelColorSettings
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
 	withFallbackStyles,

--- a/src/blocks/block-pricing-table-inner/components/description/edit.js
+++ b/src/blocks/block-pricing-table-inner/components/description/edit.js
@@ -11,7 +11,7 @@ const {
 	RichText,
 	withFontSizes,
 	withColors
-} = wp.editor;
+} = wp.blockEditor;
 
 class Edit extends Component {
 

--- a/src/blocks/block-pricing-table-inner/components/description/index.js
+++ b/src/blocks/block-pricing-table-inner/components/description/index.js
@@ -16,7 +16,7 @@ const {
 	FontSizePicker,
 	withFontSizes,
 	getColorClassName
-} = wp.editor;
+} = wp.blockEditor;
 
 // Register the block
 registerBlockType( 'atomic-blocks/ab-pricing-table-features', {

--- a/src/blocks/block-pricing-table-inner/components/description/inspector.js
+++ b/src/blocks/block-pricing-table-inner/components/description/inspector.js
@@ -18,7 +18,7 @@ const {
 	ContrastChecker,
 	PanelColorSettings,
 	ColorPalette
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
 	withFallbackStyles,

--- a/src/blocks/block-pricing-table-inner/components/global/inspector.js
+++ b/src/blocks/block-pricing-table-inner/components/global/inspector.js
@@ -20,7 +20,7 @@ const {
 	ContrastChecker,
 	PanelColorSettings,
 	RangeControl
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
 	withFallbackStyles,

--- a/src/blocks/block-pricing-table-inner/components/inspector.js
+++ b/src/blocks/block-pricing-table-inner/components/inspector.js
@@ -12,7 +12,7 @@ const { Component } = wp.element;
 const {
 	InspectorControls,
 	PanelColorSettings
-} = wp.editor;
+} = wp.blockEditor;
 
 // Import Inspector components
 const {

--- a/src/blocks/block-pricing-table-inner/components/price/deprecated/deprecated.js
+++ b/src/blocks/block-pricing-table-inner/components/price/deprecated/deprecated.js
@@ -10,7 +10,7 @@ const {
 	RichText,
 	getFontSizeClass,
 	getColorClassName
-} = wp.editor;
+} = wp.blockEditor;
 
 export const Price_1_7_0_attributes = {
 	price: {

--- a/src/blocks/block-pricing-table-inner/components/price/edit.js
+++ b/src/blocks/block-pricing-table-inner/components/price/edit.js
@@ -11,7 +11,7 @@ const {
 	RichText,
 	withFontSizes,
 	withColors
-} = wp.editor;
+} = wp.blockEditor;
 
 class Edit extends Component {
 

--- a/src/blocks/block-pricing-table-inner/components/price/index.js
+++ b/src/blocks/block-pricing-table-inner/components/price/index.js
@@ -21,7 +21,7 @@ const {
 	FontSizePicker,
 	withFontSizes,
 	getColorClassName
-} = wp.editor;
+} = wp.blockEditor;
 
 // Register the block
 registerBlockType( 'atomic-blocks/ab-pricing-table-price', {

--- a/src/blocks/block-pricing-table-inner/components/price/inspector.js
+++ b/src/blocks/block-pricing-table-inner/components/price/inspector.js
@@ -19,7 +19,7 @@ const {
 	withColors,
 	ContrastChecker,
 	PanelColorSettings
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
 	withFallbackStyles,

--- a/src/blocks/block-pricing-table-inner/components/subtitle/edit.js
+++ b/src/blocks/block-pricing-table-inner/components/subtitle/edit.js
@@ -11,7 +11,7 @@ const {
 	RichText,
 	withFontSizes,
 	withColors
-} = wp.editor;
+} = wp.blockEditor;
 
 class Edit extends Component {
 

--- a/src/blocks/block-pricing-table-inner/components/subtitle/index.js
+++ b/src/blocks/block-pricing-table-inner/components/subtitle/index.js
@@ -16,7 +16,7 @@ const {
 	FontSizePicker,
 	withFontSizes,
 	getColorClassName
-} = wp.editor;
+} = wp.blockEditor;
 
 // Register the block
 registerBlockType( 'atomic-blocks/ab-pricing-table-subtitle', {

--- a/src/blocks/block-pricing-table-inner/components/title/edit.js
+++ b/src/blocks/block-pricing-table-inner/components/title/edit.js
@@ -11,7 +11,7 @@ const {
 	RichText,
 	withFontSizes,
 	withColors
-} = wp.editor;
+} = wp.blockEditor;
 
 class Edit extends Component {
 

--- a/src/blocks/block-pricing-table-inner/components/title/index.js
+++ b/src/blocks/block-pricing-table-inner/components/title/index.js
@@ -16,7 +16,7 @@ const {
 	FontSizePicker,
 	withFontSizes,
 	getColorClassName
-} = wp.editor;
+} = wp.blockEditor;
 
 // Register the block
 registerBlockType( 'atomic-blocks/ab-pricing-table-title', {

--- a/src/blocks/block-pricing-table-inner/index.js
+++ b/src/blocks/block-pricing-table-inner/index.js
@@ -24,7 +24,7 @@ const {
 	InnerBlocks,
 	AlignmentToolbar,
 	BlockControls
-} = wp.editor;
+} = wp.blockEditor;
 
 const {
 	Fragment

--- a/src/blocks/block-pricing-table/components/inspector.js
+++ b/src/blocks/block-pricing-table/components/inspector.js
@@ -11,7 +11,7 @@ const { Component } = wp.element;
 // Import block components
 const {
 	InspectorControls
-} = wp.editor;
+} = wp.blockEditor;
 
 // Import Inspector components
 const {

--- a/src/blocks/block-pricing-table/index.js
+++ b/src/blocks/block-pricing-table/index.js
@@ -23,7 +23,7 @@ const {
 	BlockControls,
 	BlockAlignmentToolbar,
 	InnerBlocks
-} = wp.editor;
+} = wp.blockEditor;
 
 // Set allowed blocks and media
 const ALLOWED_BLOCKS = [ 'atomic-blocks/ab-pricing-table' ];

--- a/src/blocks/block-sharing/components/edit.js
+++ b/src/blocks/block-sharing/components/edit.js
@@ -12,7 +12,7 @@ const { Component } = wp.element;
 const {
 	AlignmentToolbar,
 	BlockControls
-} = wp.editor;
+} = wp.blockEditor;
 
 export default class Edit extends Component {
 	constructor() {

--- a/src/blocks/block-sharing/components/inspector.js
+++ b/src/blocks/block-sharing/components/inspector.js
@@ -11,7 +11,7 @@ const { Component } = wp.element;
 // Import block components
 const {
   InspectorControls
-} = wp.editor;
+} = wp.blockEditor;
 
 // Import Inspector components
 const {

--- a/src/blocks/block-spacer/components/inspector.js
+++ b/src/blocks/block-spacer/components/inspector.js
@@ -15,7 +15,7 @@ const {
 const {
   InspectorControls,
   PanelColorSettings
-} = wp.editor;
+} = wp.blockEditor;
 
 // Import Inspector components
 const {

--- a/src/blocks/block-testimonial/components/edit.js
+++ b/src/blocks/block-testimonial/components/edit.js
@@ -19,7 +19,7 @@ const {
 	AlignmentToolbar,
 	BlockControls,
 	MediaUpload
-} = wp.editor;
+} = wp.blockEditor;
 const {
 	Button,
 	Dashicon

--- a/src/blocks/block-testimonial/components/inspector.js
+++ b/src/blocks/block-testimonial/components/inspector.js
@@ -12,7 +12,7 @@ const { Component } = wp.element;
 const {
 	InspectorControls,
 	PanelColorSettings
-} = wp.editor;
+} = wp.blockEditor;
 
 // Import Inspector components
 const {

--- a/src/blocks/block-testimonial/components/save.js
+++ b/src/blocks/block-testimonial/components/save.js
@@ -7,7 +7,7 @@ import Testimonial from './testimonial';
  * WordPress dependencies
  */
 const { Component } = wp.element;
-const { RichText } = wp.editor;
+const { RichText } = wp.blockEditor;
 
 export default class Save extends Component {
 	constructor() {

--- a/src/utils/components/background-image/inspector.js
+++ b/src/utils/components/background-image/inspector.js
@@ -19,7 +19,7 @@ const {
 const {
 	MediaUpload,
 	MediaUploadCheck
-} = wp.editor;
+} = wp.blockEditor;
 
 class BackgroundImagePanel extends Component {
 	constructor() {

--- a/src/utils/inspector/button.js
+++ b/src/utils/inspector/button.js
@@ -11,7 +11,7 @@ const {
 } = wp.components;
 const {
 	PanelColorSettings
-} = wp.editor;
+} = wp.blockEditor;
 
 export default function ButtonSettings( props ) {
 	const {


### PR DESCRIPTION
**Summary of change:**
Update package references from wp.editor to wp.blockEditor to alleviate deprecation messages. Tested all blocks against WP 5.2 and 5.3.2.

**How to test:**

1. Load a block with the old package reference, view the deprecated message. 
2. Check out the `update-package` branch, recompile, view the same block.
3. Deprecated message should be alleviated.

<!-- If this PR is in reference to an existing issue, link it here. -->
**See:** #200 

<!-- If this PR fully resolves an existing issue, link it here. -->
**Fixes:** #200 

**Suggested Changelog Entry:**
Update package references from wp.editor to wp.blockEditor to alleviate deprecation messages.