### PR TITLE
Ensure object-fit:cover applies to image in container block

### DIFF
--- a/atomicblocks.php
+++ b/atomicblocks.php
@@ -39,6 +39,11 @@ function atomic_blocks_loader() {
 	require_once plugin_dir_path( __FILE__ ) . 'dist/getting-started/getting-started.php';
 
 	/**
+	 * Load Container Block PHP
+	 */
+	require_once plugin_dir_path( __FILE__ ) . 'src/blocks/block-container/index.php';
+
+	/**
 	 * Load Social Block PHP
 	 */
 	require_once plugin_dir_path( __FILE__ ) . 'src/blocks/block-sharing/index.php';

--- a/src/blocks/block-container/index.php
+++ b/src/blocks/block-container/index.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Server-side rendering for the container block
+ *
+ * @since   2.5.0
+ * @package Atomic Blocks
+ */
+
+/**
+ * Filters the content of a single block.
+ *
+ * @since 2.5.0
+ *
+ * @param string $block_content The block content about to be appended.
+ * @param array  $block         The full block, including name and attributes.
+ * @return string Block content.
+ */
+function atomic_blocks_filter_container_block_for_amp( $block_content, $block ) {
+	if ( ! (
+		isset( $block['blockName'] )
+		&&
+		'atomic-blocks/ab-container' !== $block['blockName']
+		&&
+		function_exists( 'is_amp_endpoint' )
+		&&
+		is_amp_endpoint()
+	) ) {
+		$block_content = preg_replace(
+			'/(?<=<img class="ab-container-image has-background-dim")/',
+			' object-fit="cover" ',
+			$block_content
+		);
+	}
+
+	return $block_content;
+}
+add_filter( 'render_block', 'atomic_blocks_filter_container_block_for_amp', 10, 2 );


### PR DESCRIPTION
<!--
Thank you so much for submitting your contribution!

A couple things:

First, anything wrapped in HTML comment tags will be ignored when you submit. So don't feel like you need to remove them before submitting, but you can if you want to. And make sure anything you **want** to be seen is **not** between HTML comment tags.

Second, any PR that you submit will be automatically:

- linted for syntax errors
- scanned for code standards violations
- checked from failing tests with the bundled test suite

If any of these fail, expect a reviewer to ask you to correct the errors before this PR can be approved.

Thanks!
-->

**Summary of change:** 
Fix container block background image to be object-fit:contain in AMP pages.

<!-- Provide a short but detailed summary of the changes included in this PR -->

**Have the changes in this PR been added to the documentation for this project?**
Does not apply

**How to test:**

1. Set up a site with https://wordpress.org/plugins/amp/
2. Set AMP website template mode to Transitional
3. Insert a container block and choose a background image.
4. View non-AMP post on frontend and take note of background.
5. Now view AMP version and see the image doesn't cover the container.

With the changes in this PR, the AMP and non-AMP version now appear the same. This is accomplished by injecting AMP's `object-fit="contain"` attribute onto the underlying background `img`, this has the effect of overriding the default `object-fit:contain` added to intrinsic-layout images in the AMP plugin.

Aside: Why is an `img` element being used for this as opposed to a CSS `background-image`? The Cover block in core uses a CSS `background-image`, so it doesn't have this problem.

Fixes: #279

**Suggested Changelog Entry:**
* Fix AMP compatibility with the Container block.

<!-- You can use this space to provide any additional information that may be relevant to this PR -->

# Screenshots

## Editor

![image](https://user-images.githubusercontent.com/134745/72287599-2f4fa180-35fc-11ea-9ed7-02dd52a7e3e9.png)

## Non-AMP

![image](https://user-images.githubusercontent.com/134745/72287628-3d052700-35fc-11ea-9209-c3403398aacb.png)

## AMP Before Fix

![image](https://user-images.githubusercontent.com/134745/72287687-55754180-35fc-11ea-9bb5-69f1c47b9bba.png)

## AMP After Fix

![image](https://user-images.githubusercontent.com/134745/72287704-5e661300-35fc-11ea-8680-337a1de2d93c.png)
