### PR TITLE
Opt to enqueue stylesheets at wp_enqueue_styles

### DIFF
--- a/dist/init.php
+++ b/dist/init.php
@@ -39,7 +39,7 @@ function atomic_blocks_block_assets() {
 		filemtime( plugin_dir_path( __FILE__ ) . 'assets/fontawesome/css/all.css' )
 	);
 }
-add_action( 'init', 'atomic_blocks_block_assets' );
+add_action( 'wp_enqueue_scripts', 'atomic_blocks_block_assets', 9 );
 
 
 /**


### PR DESCRIPTION
**Summary of change:**
In WordPress, scripts and styles which are added to the frontend should normally get enqueued at the `wp_enqueue_scripts` action. In Atomic Blocks, however, `atomic_blocks_block_assets()` runs at the `init` action. The only reason appears to be to ensure it is printed first. However, this can be accomplished by giving it a lower priority than the default (e.g. 9). 

The change here has implications for AMP compatibility. Namely, the AMP plugin adds hoosk to introspect which theme/plugin is responsible for enqueuing scripts and styles. It only adds these hooks once it knows it is going to generate an AMP page. Therefore, at the moment the AMP plugin doesn't detect that that the Font Awesome stylesheet is coming from the Atomic Blocks plugin. (This might also be due to a deficiency in the AMP plugin, but nonetheless it seems preferable to enqueue stylesheets at the `wp_enque_scripts` hook.)

**Have the changes in this PR been added to the documentation for this project?**
Does not apply

**Suggested Changelog Entry:**
* Enqueue styles at `wp_enqueue_scripts` action instead of `init`.
