### PR TITLE
Register Font Awesome stylesheet once and print only when needed

### DIFF
--- a/dist/getting-started/getting-started.php
+++ b/dist/getting-started/getting-started.php
@@ -34,7 +34,6 @@ function atomic_blocks_start_load_admin_scripts( $hook ) {
 	wp_enqueue_style( 'atomic-blocks-getting-started' );
 
 	// FontAwesome.
-	wp_register_style( 'atomic-blocks-fontawesome', plugins_url( '/assets/fontawesome/css/all' . $postfix . '.css', dirname( __FILE__ ) ), false, '1.0.0' );
 	wp_enqueue_style( 'atomic-blocks-fontawesome' );
 }
 add_action( 'admin_enqueue_scripts', 'atomic_blocks_start_load_admin_scripts' );

--- a/dist/init.php
+++ b/dist/init.php
@@ -31,8 +31,8 @@ function atomic_blocks_block_assets() {
 		filemtime( plugin_dir_path( __FILE__ ) . 'blocks.style.build.css' )
 	);
 
-	// Load the FontAwesome icon library.
-	wp_enqueue_style(
+	// Register the FontAwesome icon library.
+	wp_register_style(
 		'atomic-blocks-fontawesome',
 		plugins_url( 'dist/assets/fontawesome/css/all' . $postfix . '.css', dirname( __FILE__ ) ),
 		array(),
@@ -41,6 +41,28 @@ function atomic_blocks_block_assets() {
 }
 add_action( 'init', 'atomic_blocks_block_assets' );
 
+/**
+ * Conditionally print Font Awesome stylesheet the first time it is needed by a block.
+ *
+ * @param string $block_content Block content.
+ * @return string Block content with Font Awesome stylesheet prepended if needed.
+ */
+function atomic_blocks_prepend_block_content_with_fontawesome( $block_content ) {
+	$handle = 'atomic-blocks-fontawesome';
+	if (
+		! wp_style_is( $handle, 'done' )
+		&&
+		// Check if the content includes a class attribute that contains a Font Awesome prefix class names.
+		// For a list of the prefixes, see <https://fontawesome.com/how-to-use/on-the-web/referencing-icons/basic-use>.
+		preg_match( '/\sclass="[^"]*?(?<="|\s)(fa|fas|far|fal|fad|fab)(?=\s|")[^"]*?"/', $block_content )
+	) {
+		ob_start();
+		wp_styles()->do_items( array( $handle ) );
+		$block_content = ob_get_clean() . $block_content;
+	}
+	return $block_content;
+}
+add_filter( 'render_block', 'atomic_blocks_prepend_block_content_with_fontawesome' );
 
 /**
  * Enqueue assets for backend editor

--- a/dist/init.php
+++ b/dist/init.php
@@ -17,14 +17,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Enqueue assets for frontend and backend
  *
  * @since 1.0.0
+ *
+ * @param WP_Styles $wp_styles Styles.
  */
-function atomic_blocks_block_assets() {
+function atomic_blocks_block_assets( WP_Styles $wp_styles ) {
 
 	// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison -- Could be true or 'true'.
 	$postfix = ( SCRIPT_DEBUG == true ) ? '' : '.min';
 
 	// Load the compiled styles.
-	wp_register_style(
+	$wp_styles->add(
 		'atomic-blocks-style-css',
 		plugins_url( 'dist/blocks.style.build.css', dirname( __FILE__ ) ),
 		array(),
@@ -32,14 +34,14 @@ function atomic_blocks_block_assets() {
 	);
 
 	// Register the FontAwesome icon library.
-	wp_register_style(
+	$wp_styles->add(
 		'atomic-blocks-fontawesome',
 		plugins_url( 'dist/assets/fontawesome/css/all' . $postfix . '.css', dirname( __FILE__ ) ),
 		array(),
 		filemtime( plugin_dir_path( __FILE__ ) . 'assets/fontawesome/css/all.css' )
 	);
 }
-add_action( 'init', 'atomic_blocks_block_assets' );
+add_action( 'wp_default_styles', 'atomic_blocks_block_assets' );
 
 /**
  * Conditionally print Font Awesome stylesheet the first time it is needed by a block.
@@ -92,12 +94,7 @@ function atomic_blocks_editor_assets() {
 	);
 
 	// Load the FontAwesome icon library.
-	wp_enqueue_style(
-		'atomic-blocks-fontawesome',
-		plugins_url( 'dist/assets/fontawesome/css/all' . $postfix . '.css', dirname( __FILE__ ) ),
-		array(),
-		filemtime( plugin_dir_path( __FILE__ ) . 'assets/fontawesome/css/all.css' )
-	);
+	wp_enqueue_style( 'atomic-blocks-fontawesome' );
 
 	$user_data = wp_get_current_user();
 	unset( $user_data->user_pass, $user_data->user_email );


### PR DESCRIPTION
<!--
Thank you so much for submitting your contribution!

A couple things:

First, anything wrapped in HTML comment tags will be ignored when you submit. So don't feel like you need to remove them before submitting, but you can if you want to. And make sure anything you **want** to be seen is **not** between HTML comment tags.

Second, any PR that you submit will be automatically:

- linted for syntax errors
- scanned for code standards violations
- checked from failing tests with the bundled test suite

If any of these fail, expect a reviewer to ask you to correct the errors before this PR can be approved.

Thanks!
-->
**Summary of change:** 
The Font Awesome stylesheet is large and if it is not needed on the page then it wastes bandwidth and browser CPU cycles. It also contributes negatively to the overall CSS budget of 50KB on AMP pages (see https://github.com/ampproject/amp-wp/issues/4095). Therefore, the stylesheet should only be printed when it is actually needed by a block.

This has the added benefit of preventing the Font Awesome stylesheet from blocking the rendering content that appears before the first block that makes use of it.

This PR also centralizes the registration of the Font Awesome stylesheet in the `wp_default_styles` action, eliminating duplicated references to the stylesheet path.

**Have the changes in this PR been added to the documentation for this project?**
Does not apply

**How to test:**

1. Activate Atomic Blocks.
1. Add a block that does not require Font Awesome.
1. Check the frontend to verify that the Font Awesome has not been printed to the page.
1. Add a block that does require Font Awesome (e.g. Social Links).
1. Check the frontend to verify that the Font Awesome stylesheet has been printed once right before the dependent block.

Fixes: #127

**Suggested Changelog Entry:**
* Improve frontend performance by only printing Font Awesome stylesheet when required.