### PR TITLE
Check if featured image is available before attempting to output one.

### DIFF
--- a/src/blocks/block-post-grid/index.php
+++ b/src/blocks/block-post-grid/index.php
@@ -461,7 +461,9 @@ function atomic_blocks_get_image_src_landscape( $object, $field_name, $request )
 		'ab-block-post-grid-landscape',
 		false
 	);
-	return $feat_img_array[0];
+	if ( is_array( $feat_img_array ) ) {
+		return $feat_img_array[0];
+	}
 }
 
 /**
@@ -477,7 +479,9 @@ function atomic_blocks_get_image_src_square( $object, $field_name, $request ) {
 		'ab-block-post-grid-square',
 		false
 	);
-	return $feat_img_array[0];
+	if ( is_array( $feat_img_array ) ) {
+		return $feat_img_array[0];
+	}
 }
 
 /**


### PR DESCRIPTION
**Summary of change:**
Check if post grid image is available before outputting. 

**How to test:**
See ticket #289 for circumstances where you will see this issue. 

<!-- If this PR fully resolves an existing issue, link it here. -->
**Fixes:** #289 

**Suggested Changelog Entry:**
Fix error notice for missing thumbnails in PHP 7.4.