### PR TITLE
Do not attempt to inline Font Awesome CSS in the editor

### DIFF
--- a/dist/init.php
+++ b/dist/init.php
@@ -50,6 +50,10 @@ add_action( 'wp_default_styles', 'atomic_blocks_block_assets' );
  * @return string Block content with Font Awesome stylesheet prepended if needed.
  */
 function atomic_blocks_prepend_block_content_with_fontawesome( $block_content ) {
+	if ( is_admin() ) {
+		return $block_content;
+	}
+
 	$handle = 'atomic-blocks-fontawesome';
 	if (
 		! wp_style_is( $handle, 'done' )


### PR DESCRIPTION
Fixes the issue noted in #127 and introduced in #294, where icons in existing AB Sharing blocks will fail to load in the editor if REST requests return rendered page content that contains an AB Sharing block.

**Have the changes in this PR been added to the documentation for this project?**
No docs required.

**How to test:**
1. Add an AB Sharing block to a new page.
2. Confirm that:
    - [ ]  Icons appear in the editor when first adding the block.
    - [ ]  Icons still appear in the editor when saving the page and refreshing.
    - [ ]  Icons appear on the front end.
    - [ ]  Pages without the AB Sharing block do not load the 'all.css' Font Awesome stylesheet.

**Suggested Changelog Entry:**
Fix an issue where AB Sharing block icons could fail to load in the editor.

**Notes:**
This is branched from master and targets master since it's a patch. Happy to rebase on develop if needed, though.