### PR TITLE
Add support for filtering allowed sections and layouts.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 		"phpunit/phpunit": "^5"
 	},
 	"scripts": {
-		"phpcs": "phpcs *.php dist src -sp --runtime-set testVersion 5.6-",
+		"phpcs": "phpcs . --ignore=includes/libraries/*,includes/layout/register-layout-components.php,*vendor/* -sp --runtime-set testVersion 5.6-",
 		"phpcs-changed": "./bin/phpcs-changed.sh",
 		"phpunit": "phpunit"
 	}

--- a/includes/layout/layout-endpoints.php
+++ b/includes/layout/layout-endpoints.php
@@ -70,6 +70,13 @@ function register_layout_endpoints() {
 					return new WP_REST_Response( $all_layouts );
 				}
 
+				/**
+				 * Filters the list of sections and layouts allowed to show in the layouts library.
+				 *
+				 * @since 2.5.0
+				 *
+				 * @param array $all_layouts Array of unique layout keys allowed. Defaults to all layouts.
+				 */
 				$allowed_layouts = (array) apply_filters( 'atomic_blocks_allowed_layout_components', array_keys( $all_layouts ) );
 
 				if ( empty( $allowed_layouts ) ) {

--- a/includes/layout/layout-endpoints.php
+++ b/includes/layout/layout-endpoints.php
@@ -47,16 +47,44 @@ function register_layout_endpoints() {
 		]
 	);
 
+	/**
+	 * Register the layouts GET endpoint
+	 * that combines all sections, layouts,
+	 * and additional layouts.
+	 */
 	register_rest_route(
 		AB_API_NAMESPACE,
 		ALL_LAYOUTS_ROUTE,
 		[
 			'methods'             => WP_REST_Server::READABLE,
-			'callback'            => function () {
+			'callback'            => function ( \WP_REST_Request $request ) {
+
 				$layouts            = atomic_blocks_get_layouts();
 				$sections           = atomic_blocks_get_sections();
 				$additional_layouts = apply_filters( 'atomic_blocks_additional_layout_components', [] );
-				return new WP_REST_Response( array_merge( $layouts, $sections, $additional_layouts ) );
+				$all_layouts        = array_merge( $layouts, $sections, $additional_layouts );
+				$request_params     = $request->get_params();
+
+				// Return all layouts if filtering was not requested. "allowed" is the only filter currently supported.
+				if ( empty( $request_params['filter'] ) || 'allowed' !== $request_params['filter'] ) {
+					return new WP_REST_Response( $all_layouts );
+				}
+
+				$allowed_layouts = apply_filters( 'atomic_blocks_allowed_layout_components', [] );
+
+				if ( empty( $allowed_layouts ) ) {
+					return new WP_REST_Response( $all_layouts );
+				}
+
+				$filtered_layouts = [];
+
+				foreach ( $all_layouts as $key => $layout ) {
+					if ( in_array( $key, $allowed_layouts, true ) ) {
+						$filtered_layouts[ $key ] = $layout;
+					}
+				}
+
+				return new WP_REST_Response( $filtered_layouts );
 			},
 			'permission_callback' => function () {
 				return current_user_can( 'edit_posts' );

--- a/includes/layout/layout-endpoints.php
+++ b/includes/layout/layout-endpoints.php
@@ -70,10 +70,10 @@ function register_layout_endpoints() {
 					return new WP_REST_Response( $all_layouts );
 				}
 
-				$allowed_layouts = (array) apply_filters( 'atomic_blocks_allowed_layout_components', [] );
+				$allowed_layouts = (array) apply_filters( 'atomic_blocks_allowed_layout_components', array_keys( $all_layouts ) );
 
 				if ( empty( $allowed_layouts ) ) {
-					return new WP_REST_Response( $all_layouts );
+					return new WP_REST_Response( [] );
 				}
 
 				$filtered_layouts = [];

--- a/includes/layout/layout-endpoints.php
+++ b/includes/layout/layout-endpoints.php
@@ -70,7 +70,7 @@ function register_layout_endpoints() {
 					return new WP_REST_Response( $all_layouts );
 				}
 
-				$allowed_layouts = apply_filters( 'atomic_blocks_allowed_layout_components', [] );
+				$allowed_layouts = (array) apply_filters( 'atomic_blocks_allowed_layout_components', [] );
 
 				if ( empty( $allowed_layouts ) ) {
 					return new WP_REST_Response( $all_layouts );

--- a/src/blocks/block-layout/components/layouts-provider.js
+++ b/src/blocks/block-layout/components/layouts-provider.js
@@ -129,7 +129,7 @@ export default class LayoutsProvider extends Component {
 		wp.apiFetch(
 			{
 				'method': 'GET',
-				'path': '/atomicblocks/v1/layouts/all'
+				'path': '/atomicblocks/v1/layouts/all?filter=allowed'
 			}
 		).then( async components => {
 			let layouts = [];

--- a/tests/integration/layout-endpoints/test-layout-endpoints.php
+++ b/tests/integration/layout-endpoints/test-layout-endpoints.php
@@ -107,6 +107,9 @@ class Layout_Endpoints extends \WP_UnitTestCase {
 	public function tearDown() {
 		delete_user_meta( 1, 'atomic_blocks_favorite_layouts' );
 		wp_set_current_user( null );
+		parent::tearDown();
+		global $wp_rest_server;
+		$wp_rest_server = null;
 	}
 
 	/**
@@ -165,4 +168,43 @@ class Layout_Endpoints extends \WP_UnitTestCase {
 		$this->assertSame( $this->user_1_favorites_after_removal, $response->get_data() );
 	}
 
+	/**
+	 * Tests that the total number of layouts returned
+	 * from the API matches the expected number.
+	 */
+	public function test_layout_count() {
+		wp_set_current_user( 1 );
+		$request = new \WP_REST_Request( 'GET', '/atomicblocks/v1/layouts/all' );
+		$response = $this->server->dispatch( $request );
+		$this->assertCount( 12, json_decode( json_encode( $response->get_data() ), true ) );
+	}
+
+	/**
+	 * Tests that filtering the All Layouts endpoint
+	 * returns the expected number of layouts.
+	 */
+	function test_filtered_layout_count() {
+		wp_set_current_user( 1 );
+
+		// Filter the allowed layouts list.
+		add_filter( 'atomic_blocks_allowed_layout_components', [ __CLASS__, 'filter_layouts'] );
+
+		// Fetch the allowed layouts from the API endpoint.
+		$request = new \WP_REST_Request( 'GET', '/atomicblocks/v1/layouts/all' );
+		$request->set_param( 'filter', 'allowed' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertCount( 1, json_decode( json_encode( $response->get_data() ), true ) );
+
+		// Remove the allowed layouts filter.
+		remove_filter( 'atomic_blocks_allowed_layout_components', [ __CLASS__, 'filter_layouts'] );
+	}
+
+	/**
+	 * Filters the allowed layouts, for testing purposes.
+	 * @see `atomic_blocks_allowed_layout_components` filter.
+	 */
+	public static function filter_layouts( array $layouts ) {
+		return [ 'ab_layout_business_1' ];
+	}
 }

--- a/tests/integration/layout-endpoints/test-layout-endpoints.php
+++ b/tests/integration/layout-endpoints/test-layout-endpoints.php
@@ -7,6 +7,8 @@
 
 namespace AtomicBlocks\Tests;
 
+use function \atomic_blocks_register_layout_component;
+
 /**
  * Class Layout_Endpoints
  *
@@ -219,7 +221,7 @@ class Layout_Endpoints extends \WP_UnitTestCase {
 			]
 		);
 
-		$this->assertSame( $new_layout, true );
+		$this->assertTrue( $new_layout );
 
 		// Fetch registered layouts from API and check all the values for the one we just registered.
 		$layouts = atomic_blocks_get_layouts();
@@ -244,7 +246,7 @@ class Layout_Endpoints extends \WP_UnitTestCase {
 	 * Tests that registering an invalid component type fails
 	 * and returns a WP_Error object.
 	 *
-	 * @covers atomic_blocks_register_layout_component()
+	 * @covers ::atomic_blocks_register_layout_component()
 	 */
 	public function test_register_invalid_layout_component_fails() {
 		$new_layout = atomic_blocks_register_layout_component(
@@ -259,15 +261,20 @@ class Layout_Endpoints extends \WP_UnitTestCase {
 	/**
 	 * Tests that unregistering an existing layout component succeeds.
 	 *
-	 * @covers atomic_blocks_unregister_layout_component()
+	 * @covers ::atomic_blocks_unregister_layout_component()
 	 */
 	public function test_unregister_existing_layout_component_succeeds() {
 		$success = atomic_blocks_unregister_layout_component( 'layout', 'ab_layout_business_1' );
-		$this->assertSame( $success, true );
+		$this->assertTrue( $success );
 		$layouts = atomic_blocks_get_layouts();
 		$this->assertArrayNotHasKey( 'ab_layout_business_1', $layouts );
 	}
 
+	/**
+	 * Tests layout fetching functionality.
+	 *
+	 * @covers ::atomic_blocks_get_layouts()
+	 */
 	public function test_get_layouts() {
 		$layouts = atomic_blocks_get_layouts();
 		$this->assertArrayHasKey( 'ab_integration_test_layout_1', $layouts );

--- a/tests/integration/layout-endpoints/test-layout-endpoints.php
+++ b/tests/integration/layout-endpoints/test-layout-endpoints.php
@@ -174,35 +174,38 @@ class Layout_Endpoints extends \WP_UnitTestCase {
 	 */
 	public function test_layout_count() {
 		wp_set_current_user( 1 );
-		$request = new \WP_REST_Request( 'GET', '/atomicblocks/v1/layouts/all' );
+		$request  = new \WP_REST_Request( 'GET', '/atomicblocks/v1/layouts/all' );
 		$response = $this->server->dispatch( $request );
-		$this->assertCount( 12, json_decode( json_encode( $response->get_data() ), true ) );
+		$this->assertCount( 12, json_decode( wp_json_encode( $response->get_data() ), true ) );
 	}
 
 	/**
 	 * Tests that filtering the All Layouts endpoint
 	 * returns the expected number of layouts.
 	 */
-	function test_filtered_layout_count() {
+	public function test_filtered_layout_count() {
 		wp_set_current_user( 1 );
 
 		// Filter the allowed layouts list.
-		add_filter( 'atomic_blocks_allowed_layout_components', [ __CLASS__, 'filter_layouts'] );
+		add_filter( 'atomic_blocks_allowed_layout_components', [ __CLASS__, 'filter_layouts' ] );
 
 		// Fetch the allowed layouts from the API endpoint.
 		$request = new \WP_REST_Request( 'GET', '/atomicblocks/v1/layouts/all' );
 		$request->set_param( 'filter', 'allowed' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertCount( 1, json_decode( json_encode( $response->get_data() ), true ) );
+		$this->assertCount( 1, json_decode( wp_json_encode( $response->get_data() ), true ) );
 
 		// Remove the allowed layouts filter.
-		remove_filter( 'atomic_blocks_allowed_layout_components', [ __CLASS__, 'filter_layouts'] );
+		remove_filter( 'atomic_blocks_allowed_layout_components', [ __CLASS__, 'filter_layouts' ] );
 	}
 
 	/**
 	 * Filters the allowed layouts, for testing purposes.
+	 *
 	 * @see `atomic_blocks_allowed_layout_components` filter.
+	 * @param array $layouts Array of allowed layouts.
+	 * @return array
 	 */
 	public static function filter_layouts( array $layouts ) {
 		return [ 'ab_layout_business_1' ];


### PR DESCRIPTION
**Summary of change:**
- Adds `atomic_blocks_allowed_layout_components` filter for controlling layouts shown in the modal.
- Adds `filter=allowed` param to All Layouts endpoint. Follows WPE standard for filtering endpoint data in HTTP APIs.
- Updates phpcs command line options in composer.json for better coverage and easier maintenance.
- Adds test coverage for new filtering feature, and some additional coverage for existing functionality.

**How to test:**
- Check out `allowed/layouts` branch, run `npm run start`, and ensure nothing is broken.
- Test filtering the allowed layouts and ensure only the ones you allowed are shown in the modal. Example filter to get you started:
```
add_filter( 'atomic_blocks_allowed_layout_components', function( $layouts ) {
	return ['ab_layout_hero_1', 'ab_layout_service_1'];
});
```
