### PR TITLE
Improve column styles for Gutenberg plugin

### DIFF
--- a/src/blocks/block-column-inner/styles/editor.scss
+++ b/src/blocks/block-column-inner/styles/editor.scss
@@ -12,12 +12,14 @@
 	max-width: 100%;
 }
 
-.edit-post-visual-editor .editor-block-list__block [data-type="atomic-blocks/ab-column"] {
+.edit-post-visual-editor .editor-block-list__block [data-type="atomic-blocks/ab-column"],
+.edit-post-visual-editor .block-editor-block-list__block [data-type="atomic-blocks/ab-column"] {
     margin-left: 0;
 	margin-right: 0;
 }
 
-.ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+.ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout,
+.ab-layout-column-wrap-admin > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	display: -ms-grid;
 	display: grid;
 	-ms-grid-rows: 1fr;
@@ -28,47 +30,58 @@
 
 /* Grid gap classes */
 
-.ab-block-layout-column-gap-0 > .editor-inner-blocks > .editor-block-list__layout {
+.ab-block-layout-column-gap-0 > .editor-inner-blocks > .editor-block-list__layout,
+.ab-block-layout-column-gap-0 > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	grid-gap: 0 0;
 }
 
-.ab-block-layout-column-gap-1 > .editor-inner-blocks > .editor-block-list__layout {
+.ab-block-layout-column-gap-1 > .editor-inner-blocks > .editor-block-list__layout,
+.ab-block-layout-column-gap-1 > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	grid-gap: 0 1em;
 }
 
-.ab-block-layout-column-gap-2 > .editor-inner-blocks > .editor-block-list__layout {
+.ab-block-layout-column-gap-2 > .editor-inner-blocks > .editor-block-list__layout,
+.ab-block-layout-column-gap-2 > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	grid-gap: 0 2em;
 }
 
-.ab-block-layout-column-gap-3 > .editor-inner-blocks > .editor-block-list__layout {
+.ab-block-layout-column-gap-3 > .editor-inner-blocks > .editor-block-list__layout,
+.ab-block-layout-column-gap-3 > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	grid-gap: 0 3em;
 }
 
-.ab-block-layout-column-gap-4 > .editor-inner-blocks > .editor-block-list__layout {
+.ab-block-layout-column-gap-4 > .editor-inner-blocks > .editor-block-list__layout,
+.ab-block-layout-column-gap-4 > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	grid-gap: 0 4em;
 }
 
-.ab-block-layout-column-gap-5 > .editor-inner-blocks > .editor-block-list__layout {
+.ab-block-layout-column-gap-5 > .editor-inner-blocks > .editor-block-list__layout,
+.ab-block-layout-column-gap-5 > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	grid-gap: 0 5em;
 }
 
-.ab-block-layout-column-gap-6 > .editor-inner-blocks > .editor-block-list__layout {
+.ab-block-layout-column-gap-6 > .editor-inner-blocks > .editor-block-list__layout,
+.ab-block-layout-column-gap-6 > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	grid-gap: 0 6em;
 }
 
-.ab-block-layout-column-gap-7 > .editor-inner-blocks > .editor-block-list__layout {
+.ab-block-layout-column-gap-7 > .editor-inner-blocks > .editor-block-list__layout,
+.ab-block-layout-column-gap-7 > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	grid-gap: 0 7em;
 }
 
-.ab-block-layout-column-gap-8 > .editor-inner-blocks > .editor-block-list__layout {
+.ab-block-layout-column-gap-8 > .editor-inner-blocks > .editor-block-list__layout,
+.ab-block-layout-column-gap-8 > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	grid-gap: 0 8em;
 }
 
-.ab-block-layout-column-gap-9 > .editor-inner-blocks > .editor-block-list__layout {
+.ab-block-layout-column-gap-9 > .editor-inner-blocks > .editor-block-list__layout,
+.ab-block-layout-column-gap-9 > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	grid-gap: 0 9em;
 }
 
-.ab-block-layout-column-gap-10 > .editor-inner-blocks > .editor-block-list__layout {
+.ab-block-layout-column-gap-10 > .editor-inner-blocks > .editor-block-list__layout,
+.ab-block-layout-column-gap-10 > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	grid-gap: 0 10em;
 }
 
@@ -76,37 +89,43 @@
 
 /* IE 11 support - Rows and column location must be explicitly defined. */
 
-.ab-layout-column-wrap-admin .editor-block-list__layout [data-type="atomic-blocks/ab-column"]:nth-child(1) {
+.ab-layout-column-wrap-admin .editor-block-list__layout [data-type="atomic-blocks/ab-column"]:nth-child(1),
+.ab-layout-column-wrap-admin .block-editor-block-list__layout [data-type="atomic-blocks/ab-column"]:nth-child(1) {
 	-ms-grid-row: 1;
 	-ms-grid-column: 1;
 	grid-area: col1;
 }
 
-.ab-layout-column-wrap-admin .editor-block-list__layout [data-type="atomic-blocks/ab-column"]:nth-child(2) {
+.ab-layout-column-wrap-admin .editor-block-list__layout [data-type="atomic-blocks/ab-column"]:nth-child(2),
+.ab-layout-column-wrap-admin .block-editor-block-list__layout [data-type="atomic-blocks/ab-column"]:nth-child(2) {
 	-ms-grid-row: 1;
 	-ms-grid-column: 2;
 	grid-area: col2;
 }
 
-.ab-layout-column-wrap-admin .editor-block-list__layout [data-type="atomic-blocks/ab-column"]:nth-child(3) {
+.ab-layout-column-wrap-admin .editor-block-list__layout [data-type="atomic-blocks/ab-column"]:nth-child(3),
+.ab-layout-column-wrap-admin .block-editor-block-list__layout [data-type="atomic-blocks/ab-column"]:nth-child(3) {
 	-ms-grid-row: 1;
 	-ms-grid-column: 3;
 	grid-area: col3;
 }
 
-.ab-layout-column-wrap-admin .editor-block-list__layout [data-type="atomic-blocks/ab-column"]:nth-child(4) {
+.ab-layout-column-wrap-admin .editor-block-list__layout [data-type="atomic-blocks/ab-column"]:nth-child(4),
+.ab-layout-column-wrap-admin .block-editor-block-list__layout [data-type="atomic-blocks/ab-column"]:nth-child(4) {
 	-ms-grid-row: 1;
 	-ms-grid-column: 4;
 	grid-area: col4;
 }
 
-.ab-layout-column-wrap-admin .editor-block-list__layout [data-type="atomic-blocks/ab-column"]:nth-child(5) {
+.ab-layout-column-wrap-admin .editor-block-list__layout [data-type="atomic-blocks/ab-column"]:nth-child(5),
+.ab-layout-column-wrap-admin .block-editor-block-list__layout [data-type="atomic-blocks/ab-column"]:nth-child(5) {
 	-ms-grid-row: 1;
 	-ms-grid-column: 5;
 	grid-area: col5;
 }
 
-.ab-layout-column-wrap-admin .editor-block-list__layout [data-type="atomic-blocks/ab-column"]:nth-child(6) {
+.ab-layout-column-wrap-admin .editor-block-list__layout [data-type="atomic-blocks/ab-column"]:nth-child(6),
+.ab-layout-column-wrap-admin .block-editor-block-list__layout [data-type="atomic-blocks/ab-column"]:nth-child(6) {
 	-ms-grid-row: 1;
 	-ms-grid-column: 6;
 	grid-area: col6;
@@ -114,7 +133,8 @@
 
 /* One column grid. */
 
-.ab-layout-columns-1 > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+.ab-layout-columns-1 > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout,
+.ab-layout-columns-1 > .ab-layout-column-wrap-admin > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	-ms-grid-columns: 1fr;
 	grid-template-columns: 1fr;
 	grid-template-areas: "col1";
@@ -122,72 +142,84 @@
 
 /* Two column grid. */
 
-.ab-layout-columns-2 > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+.ab-layout-columns-2 > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout,
+.ab-layout-columns-2 > .ab-layout-column-wrap-admin > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	-ms-grid-columns: 1fr 1fr;
 	grid-template-columns: 1fr 1fr;
 	grid-template-areas: "col1 col2";
 }
 
-.ab-2-col-wideleft > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+.ab-2-col-wideleft > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout,
+.ab-2-col-wideleft > .ab-layout-column-wrap-admin > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	-ms-grid-columns: 2fr 1fr;
 	grid-template-columns: 2fr 1fr;
 }
 
-.ab-2-col-wideright > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+.ab-2-col-wideright > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout,
+.ab-2-col-wideright > .ab-layout-column-wrap-admin > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	-ms-grid-columns: 1fr 2fr;
 	grid-template-columns: 1fr 2fr;
 }
 
 /* Three column grid. */
 
-.ab-layout-columns-3 > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+.ab-layout-columns-3 > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout,
+.ab-layout-columns-3 > .ab-layout-column-wrap-admin > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	-ms-grid-columns: 1fr 1fr 1fr;
 	grid-template-columns: 1fr 1fr 1fr;
 	grid-template-areas: "col1 col2 col3";
 }
 
-.ab-3-col-widecenter > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+.ab-3-col-widecenter > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout,
+.ab-3-col-widecenter > .ab-layout-column-wrap-admin > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	-ms-grid-columns: 1fr 2fr 1fr;
 	grid-template-columns: 1fr 2fr 1fr;
 }
 
-.ab-3-col-wideleft > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+.ab-3-col-wideleft > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout,
+.ab-3-col-wideleft > .ab-layout-column-wrap-admin > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	-ms-grid-columns: 2fr 1fr 1fr;
 	grid-template-columns: 2fr 1fr 1fr;
 }
 
-.ab-3-col-wideright > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+.ab-3-col-wideright > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout,
+.ab-3-col-wideright > .ab-layout-column-wrap-admin > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	-ms-grid-columns: 1fr 1fr 2fr;
 	grid-template-columns: 1fr 1fr 2fr;
 }
 
 /* Four column grid. */
 
-.ab-layout-columns-4 > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+.ab-layout-columns-4 > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout,
+.ab-layout-columns-4 > .ab-layout-column-wrap-admin > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	-ms-grid-columns: 1fr 1fr 1fr 1fr;
 	grid-template-columns: 1fr 1fr 1fr 1fr;
 	grid-template-areas: "col1 col2 col3 col4";
 }
 
-.ab-4-col-wideleft > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+.ab-4-col-wideleft > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout,
+.ab-4-col-wideleft > .ab-layout-column-wrap-admin > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	-ms-grid-columns: 2fr 1fr 1fr 1fr;
 	grid-template-columns: 2fr 1fr 1fr 1fr;
 }
 
-.ab-4-col-wideright > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+.ab-4-col-wideright > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout,
+.ab-4-col-wideright > .ab-layout-column-wrap-admin > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	-ms-grid-columns: 1fr 1fr 1fr 2fr;
 	grid-template-columns: 1fr 1fr 1fr 2fr;
 }
 
 /* Five column grid. */
 
-.ab-layout-columns-5 > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+.ab-layout-columns-5 > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout,
+.ab-layout-columns-5 > .ab-layout-column-wrap-admin > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	-ms-grid-columns: 1fr 1fr 1fr 1fr 1fr;
 	grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
 	grid-template-areas: "col1 col2 col3 col4 col5";
 }
 
-.ab-layout-columns-6 > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout {
+.ab-layout-columns-6 > .ab-layout-column-wrap-admin > .editor-inner-blocks > .editor-block-list__layout,
+.ab-layout-columns-6 > .ab-layout-column-wrap-admin > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	-ms-grid-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
 	grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
 	grid-template-areas: "col1 col2 col3 col4 col5 col6";
@@ -202,7 +234,9 @@
 /* Alignment styles */
 
 .ab-block-layout-column .editor-block-list__block[data-align=full],
-.ab-block-layout-column .editor-block-list__block[data-align=wide] {
+.ab-block-layout-column .block-editor-block-list__block[data-align=wide],
+.ab-block-layout-column .editor-block-list__block[data-align=full],
+.ab-block-layout-column .block-editor-block-list__block[data-align=wide] {
 	margin-left: auto;
 	margin-right: auto;
 }


### PR DESCRIPTION
**Summary of change:**
Users reported that columns and container did not work in latest Gutenberg 7.4.0 release. This is because the plugin has introduced new `block-` prefixes on markup in the editor. Until this change is merged into core, we'll have to maintain both styles to accommodate users who are using the plugin.

I did not find any issues with the container block, nor does it contain any particular editor styles that should conflict.

**How to test:**

1. Switch to `master` and activate the latest Gutenberg plugin.
2. Create a 3 column layout in a page.
3. Observe the stacked columns.
4. Pull down `issue/298` and run the build. 
5. Check to see if the columns are fixed.

<!-- If this PR is in reference to an existing issue, link it here. -->
**See:** #298 

<!-- If this PR fully resolves an existing issue, link it here. -->
**Fixes:** #298 

**Suggested Changelog Entry:**
Improve styles for users who are experimenting with the latest Gutenberg plugin.