### PR TITLE
Add missing comma in post grid styles

### DIFF
--- a/src/blocks/block-post-grid/styles/style.scss
+++ b/src/blocks/block-post-grid/styles/style.scss
@@ -69,7 +69,7 @@
 		}
 	}
 
-	.is-grid.columns-4
+	.is-grid.columns-4,
 	.ab-is-grid.ab-columns-4 {
 		-ms-grid-columns: 1fr 1fr 1fr 1fr;
 		grid-template-columns: 1fr 1fr 1fr 1fr;


### PR DESCRIPTION
**Summary of change:**
Add the missing comma to post grid styles.

**How to test:**
Check out the branch, add the post grid block, and try to create a four column layout. You should get a proper four column layout.

<!-- If this PR is in reference to an existing issue, link it here. -->
**See:** #313 

<!-- If this PR fully resolves an existing issue, link it here. -->
**Fixes:** #313 

**Suggested Changelog Entry:**
Fix four column layout styles in Post Grid block.

<!-- You can use this space to provide any additional information that may be relevant to this PR -->
