### PR TITLE
Defer title size to theme

### DIFF
--- a/src/blocks/block-post-grid/styles/style.scss
+++ b/src/blocks/block-post-grid/styles/style.scss
@@ -113,8 +113,6 @@
 	header .ab-block-post-grid-title {
 		margin-top: 0;
 		margin-bottom: 15px;
-		font-size: 28px;
-		line-height: 1.2;
 
 		a {
 			color: $black;


### PR DESCRIPTION
**Summary of change:**
Remove this explicit font size and defer the font size to the theme. These block styles are now being shared by the post and portfolio block. In order to keep the font sizes consistent in full page layouts, the styles should defer to the theme.

**How to test:**
Add the post grid or portfolio to the page and confirm that the title size uses the theme's title size.

**Suggested Changelog Entry:**
Improve the title font size to match the theme's styles.

<!-- You can use this space to provide any additional information that may be relevant to this PR -->
