### PR TITLE
Allow shortcode block in pricing table. #316

### DIFF
--- a/src/blocks/block-pricing-table-inner/index.js
+++ b/src/blocks/block-pricing-table-inner/index.js
@@ -38,7 +38,8 @@ const ALLOWED_BLOCKS = [
 	'atomic-blocks/ab-pricing-table-button',
 	'core/paragraph',
 	'core/image',
-	'core/html'
+	'core/html',
+	'core/shortcode'
 ];
 
 class ABPricingTableBlock extends Component {


### PR DESCRIPTION
Adds support for shortcode block in pricing table.

Closes #316.

