### PR TITLE
Tweak plugin loader code to avoid possible PHP fatal errors under certain conditions.

### DIFF
--- a/atomicblocks.php
+++ b/atomicblocks.php
@@ -20,128 +20,28 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Initialize the blocks
- */
-function atomic_blocks_loader() {
-
-	$atomic_blocks_includes_dir = plugin_dir_path( __FILE__ ) . 'includes/';
-	$atomic_blocks_src_dir      = plugin_dir_path( __FILE__ ) . 'src/';
-	$atomic_blocks_dist_dir     = plugin_dir_path( __FILE__ ) . 'dist/';
-
-	/**
-	 * Load the blocks functionality
-	 */
-	require_once plugin_dir_path( __FILE__ ) . 'dist/init.php';
-
-	/**
-	 * Load Getting Started page
-	 */
-	require_once plugin_dir_path( __FILE__ ) . 'dist/getting-started/getting-started.php';
-
-	/**
-	 * Load Container Block PHP
-	 */
-	require_once plugin_dir_path( __FILE__ ) . 'src/blocks/block-container/index.php';
-
-	/**
-	 * Load Social Block PHP
-	 */
-	require_once plugin_dir_path( __FILE__ ) . 'src/blocks/block-sharing/index.php';
-
-	/**
-	 * Load Post Grid PHP
-	 */
-	require_once plugin_dir_path( __FILE__ ) . 'src/blocks/block-post-grid/index.php';
-
-	/**
-	 * Load the newsletter block and related dependencies.
-	 */
-	if ( PHP_VERSION_ID >= 50600 ) {
-		if ( ! class_exists( '\DrewM\MailChimp\MailChimp' ) ) {
-			require_once $atomic_blocks_includes_dir . 'libraries/drewm/mailchimp-api/MailChimp.php';
-		}
-
-		require_once $atomic_blocks_includes_dir . 'exceptions/class-api-error-exception.php';
-		require_once $atomic_blocks_includes_dir . 'exceptions/class-mailchimp-api-error-exception.php';
-		require_once $atomic_blocks_includes_dir . 'interfaces/newsletter-provider-interface.php';
-		require_once $atomic_blocks_includes_dir . 'classes/class-mailchimp.php';
-		require_once $atomic_blocks_includes_dir . 'newsletter/newsletter-functions.php';
-		require_once $atomic_blocks_src_dir . 'blocks/block-newsletter/index.php';
-	}
-
-	/**
-	 * Layout Component Registry.
-	 */
-	if ( PHP_VERSION_ID >= 50600 ) {
-		require_once $atomic_blocks_includes_dir . 'layout/layout-functions.php';
-		require_once $atomic_blocks_includes_dir . 'layout/class-component-registry.php';
-		require_once $atomic_blocks_includes_dir . 'layout/register-layout-components.php';
-
-		/**
-		 * REST API Endpoints for Layouts.
-		 */
-		require_once $atomic_blocks_includes_dir . 'layout/layout-endpoints.php';
-	}
-
-	/**
-	 * Compatibility functionality.
-	 */
-	require_once $atomic_blocks_includes_dir . 'compat.php';
-}
-add_action( 'plugins_loaded', 'atomic_blocks_loader' );
-
-
-/**
- * Load the plugin textdomain
- */
-function atomic_blocks_init() {
-	load_plugin_textdomain( 'atomic-blocks', false, basename( dirname( __FILE__ ) ) . '/languages' );
-}
-add_action( 'init', 'atomic_blocks_init' );
-
-
-/**
- * Adds a redirect option during plugin activation on non-multisite installs.
+ * To ensure no conflicts with Atomic Blocks, we check to see
+ * if this function exists before bootstrapping the rest
+ * of the plugin.
  *
- * @param bool $network_wide Whether or not the plugin is being network activated.
+ * Why? Example: Atomic Blocks Pro bundles the free Atomic Blocks
+ * inside lib/atomic-blocks. If someone programmatically installs
+ * Atomic Blocks via wp-cli, or something like Genesis OCTS, there's
+ * a chance WordPress will include the AB plugin file and cause a
+ * PHP fatal error due to functions already being declared.
+ * This simple check prevents the fatal error from happening
+ * and only loads the rest of the plugin when it's safe.
  */
-function atomic_blocks_activate( $network_wide = false ) {
-	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Only used to do a redirect. False positive.
-	if ( ! $network_wide && ! isset( $_GET['activate-multi'] ) ) {
-		add_option( 'atomic_blocks_do_activation_redirect', true );
+if ( ! function_exists( 'atomic_blocks_main_plugin_file' ) ) {
+	/**
+	 * Returns the full path and filename of the main Atomic Blocks plugin file.
+	 *
+	 * @return string
+	 */
+	function atomic_blocks_main_plugin_file() {
+		return __FILE__;
 	}
-}
-register_activation_hook( __FILE__, 'atomic_blocks_activate' );
 
-
-/**
- * Redirect to the Atomic Blocks Getting Started page on single plugin activation.
- */
-function atomic_blocks_redirect() {
-	if ( get_option( 'atomic_blocks_do_activation_redirect', false ) ) {
-		delete_option( 'atomic_blocks_do_activation_redirect' );
-		wp_safe_redirect( esc_url( admin_url( 'admin.php?page=atomic-blocks' ) ) );
-		exit;
-	}
-}
-add_action( 'admin_init', 'atomic_blocks_redirect' );
-
-
-/**
- * Add image sizes
- */
-function atomic_blocks_image_sizes() {
-	// Post Grid Block.
-	add_image_size( 'ab-block-post-grid-landscape', 600, 400, true );
-	add_image_size( 'ab-block-post-grid-square', 600, 600, true );
-}
-add_action( 'after_setup_theme', 'atomic_blocks_image_sizes' );
-
-/**
- * Returns the full path and filename of the main Atomic Blocks plugin file.
- *
- * @return string
- */
-function atomic_blocks_main_plugin_file() {
-	return __FILE__;
+	// Load the rest of the plugin.
+	require_once 'loader.php';
 }

--- a/loader.php
+++ b/loader.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Bootstraps the Atomic Blocks plugin.
+ *
+ * @package AtomicBlocks
+ */
+
+/**
+ * Initialize the blocks
+ */
+function atomic_blocks_loader() {
+
+	$atomic_blocks_includes_dir = plugin_dir_path( __FILE__ ) . 'includes/';
+	$atomic_blocks_src_dir      = plugin_dir_path( __FILE__ ) . 'src/';
+	$atomic_blocks_dist_dir     = plugin_dir_path( __FILE__ ) . 'dist/';
+
+	/**
+	 * Load the blocks functionality
+	 */
+	require_once plugin_dir_path( __FILE__ ) . 'dist/init.php';
+
+	/**
+	 * Load Getting Started page
+	 */
+	require_once plugin_dir_path( __FILE__ ) . 'dist/getting-started/getting-started.php';
+
+	/**
+	 * Load Container Block PHP
+	 */
+	require_once plugin_dir_path( __FILE__ ) . 'src/blocks/block-container/index.php';
+
+	/**
+	 * Load Social Block PHP
+	 */
+	require_once plugin_dir_path( __FILE__ ) . 'src/blocks/block-sharing/index.php';
+
+	/**
+	 * Load Post Grid PHP
+	 */
+	require_once plugin_dir_path( __FILE__ ) . 'src/blocks/block-post-grid/index.php';
+
+	/**
+	 * Load the newsletter block and related dependencies.
+	 */
+	if ( PHP_VERSION_ID >= 50600 ) {
+		if ( ! class_exists( '\DrewM\MailChimp\MailChimp' ) ) {
+			require_once $atomic_blocks_includes_dir . 'libraries/drewm/mailchimp-api/MailChimp.php';
+		}
+
+		require_once $atomic_blocks_includes_dir . 'exceptions/class-api-error-exception.php';
+		require_once $atomic_blocks_includes_dir . 'exceptions/class-mailchimp-api-error-exception.php';
+		require_once $atomic_blocks_includes_dir . 'interfaces/newsletter-provider-interface.php';
+		require_once $atomic_blocks_includes_dir . 'classes/class-mailchimp.php';
+		require_once $atomic_blocks_includes_dir . 'newsletter/newsletter-functions.php';
+		require_once $atomic_blocks_src_dir . 'blocks/block-newsletter/index.php';
+	}
+
+	/**
+	 * Layout Component Registry.
+	 */
+	if ( PHP_VERSION_ID >= 50600 ) {
+		require_once $atomic_blocks_includes_dir . 'layout/layout-functions.php';
+		require_once $atomic_blocks_includes_dir . 'layout/class-component-registry.php';
+		require_once $atomic_blocks_includes_dir . 'layout/register-layout-components.php';
+
+		/**
+		 * REST API Endpoints for Layouts.
+		 */
+		require_once $atomic_blocks_includes_dir . 'layout/layout-endpoints.php';
+	}
+
+	/**
+	 * Compatibility functionality.
+	 */
+	require_once $atomic_blocks_includes_dir . 'compat.php';
+}
+add_action( 'plugins_loaded', 'atomic_blocks_loader' );
+
+
+/**
+ * Load the plugin textdomain
+ */
+function atomic_blocks_init() {
+	load_plugin_textdomain( 'atomic-blocks', false, basename( dirname( __FILE__ ) ) . '/languages' );
+}
+add_action( 'init', 'atomic_blocks_init' );
+
+
+/**
+ * Adds a redirect option during plugin activation on non-multisite installs.
+ *
+ * @param bool $network_wide Whether or not the plugin is being network activated.
+ */
+function atomic_blocks_activate( $network_wide = false ) {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Only used to do a redirect. False positive.
+	if ( ! $network_wide && ! isset( $_GET['activate-multi'] ) ) {
+		add_option( 'atomic_blocks_do_activation_redirect', true );
+	}
+}
+register_activation_hook( __FILE__, 'atomic_blocks_activate' );
+
+
+/**
+ * Redirect to the Atomic Blocks Getting Started page on single plugin activation.
+ */
+function atomic_blocks_redirect() {
+	if ( get_option( 'atomic_blocks_do_activation_redirect', false ) ) {
+		delete_option( 'atomic_blocks_do_activation_redirect' );
+		wp_safe_redirect( esc_url( admin_url( 'admin.php?page=atomic-blocks' ) ) );
+		exit;
+	}
+}
+add_action( 'admin_init', 'atomic_blocks_redirect' );
+
+
+/**
+ * Add image sizes
+ */
+function atomic_blocks_image_sizes() {
+	// Post Grid Block.
+	add_image_size( 'ab-block-post-grid-landscape', 600, 400, true );
+	add_image_size( 'ab-block-post-grid-square', 600, 600, true );
+}
+add_action( 'after_setup_theme', 'atomic_blocks_image_sizes' );


### PR DESCRIPTION
Closes #330.

To test this, do the following:

- Install latest AB Pro beta
- Clone this branch into wp-content/plugins/atomic-blocks, but leave the plugin deactivated.
- Install a Genesis OCTS theme, like Essence Pro.
- Go to Appearance > Child Theme Setup and click "Set up your website" button.

These steps mimic what Genesis would do if this fix were already deployed to wp.org. When Genesis instructs WP to activate the code in this branch, you should not see any fatal errors and the OCTS process should complete like normal.

See the comment in the main `atomicblocks.php` file for more info. Nearly all the logic that lived in the main plugin file now lives in `loader.php` and was not changed.