### PR TITLE
Add page select feature to post grid

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
     "react-lazy-load": "^3.0.13",
+    "react-select": "^3.1.0",
     "sass-loader": "^8.0.2",
     "webpack": "^4.42.0"
   },

--- a/src/blocks/block-post-grid/components/edit.js
+++ b/src/blocks/block-post-grid/components/edit.js
@@ -291,10 +291,13 @@ export default compose( [
 		const pageIDs = props.attributes.selectedPages && props.attributes.selectedPages.length > 0 ? props.attributes.selectedPages.map(obj => obj.value) : null;
 
 		// Query for pages
-		const pageQuery = pickBy({
-			include: pageIDs ? pageIDs : null,
-			orderby: pageIDs ? 'include' : null,
-		}, ( value ) => ! isUndefined( value ) );
+		const pageQuery = pickBy(
+			{
+				include: pageIDs ? pageIDs : null,
+				orderby: pageIDs ? 'include' : null,
+			},
+			( value ) => ! isUndefined( value )
+		);
 
 		// Return the post or page query
 		return {

--- a/src/blocks/block-post-grid/components/edit.js
+++ b/src/blocks/block-post-grid/components/edit.js
@@ -287,12 +287,27 @@ export default compose( [
 			( value ) => ! isUndefined( value )
 		);
 
+		// Grab the array string from the inspector
+		const pageSelection = JSON.parse( props.attributes.selectedPages );
+
+		// Grab the page IDs from the array
+		const pageIDs = pageSelection && pageSelection.length > 0 ? pageSelection.map(obj => obj.value) : null;
+
+		// Query for pages
+		const pageQuery = pickBy({
+			include: pageIDs && pageIDs.length > 0 ? pageIDs : null,
+			orderby: pageIDs && pageIDs.length > 0 ? 'include' : null,
+		}, ( value ) => ! isUndefined( value ) );
+
+		// Return the post or page query
 		return {
 			latestPosts: getEntityRecords(
 				'postType',
 				props.attributes.postType,
-				latestPostsQuery
-			),
+				'page' === props.attributes.postType && pageIDs && pageIDs.length > 0
+				? pageQuery
+				: latestPostsQuery
+			)
 		};
 	} ),
 ] )( LatestPostsBlock );

--- a/src/blocks/block-post-grid/components/edit.js
+++ b/src/blocks/block-post-grid/components/edit.js
@@ -287,16 +287,13 @@ export default compose( [
 			( value ) => ! isUndefined( value )
 		);
 
-		// Grab the array string from the inspector
-		const pageSelection = JSON.parse( props.attributes.selectedPages );
-
 		// Grab the page IDs from the array
-		const pageIDs = pageSelection && pageSelection.length > 0 ? pageSelection.map(obj => obj.value) : null;
+		const pageIDs = props.attributes.selectedPages && props.attributes.selectedPages.length > 0 ? props.attributes.selectedPages.map(obj => obj.value) : null;
 
 		// Query for pages
 		const pageQuery = pickBy({
-			include: pageIDs && pageIDs.length > 0 ? pageIDs : null,
-			orderby: pageIDs && pageIDs.length > 0 ? 'include' : null,
+			include: pageIDs ? pageIDs : null,
+			orderby: pageIDs ? 'include' : null,
 		}, ( value ) => ! isUndefined( value ) );
 
 		// Return the post or page query
@@ -304,7 +301,7 @@ export default compose( [
 			latestPosts: getEntityRecords(
 				'postType',
 				props.attributes.postType,
-				'page' === props.attributes.postType && pageIDs && pageIDs.length > 0
+				'page' === props.attributes.postType && pageIDs
 				? pageQuery
 				: latestPostsQuery
 			)

--- a/src/blocks/block-post-grid/components/inspector.js
+++ b/src/blocks/block-post-grid/components/inspector.js
@@ -9,6 +9,7 @@ const { Component, Fragment } = wp.element;
 import compact from 'lodash/compact';
 import map from 'lodash/map';
 import RenderSettingControl from '../../../utils/components/settings/renderSettingControl';
+import Select from 'react-select';
 
 // Import block components
 const { InspectorControls } = wp.blockEditor;
@@ -71,6 +72,18 @@ export default class Inspector extends Component {
 				};
 			} )
 		);
+	}
+
+	/* Get the page list */
+	pageSelect() {
+		const getPages = wp.data.select( 'core' ).getEntityRecords( 'postType', 'page', { per_page: -1 } )
+
+		return compact( map( getPages, ({ id, title }) => {
+			return {
+				value: id,
+				label: title.raw
+			};
+		}) );
 	}
 
 	render() {
@@ -147,6 +160,9 @@ export default class Inspector extends Component {
 			return 'full';
 		};
 
+		// Setup the page select options
+		const pageOptions = this.pageSelect();
+
 		return (
 			<InspectorControls>
 				<PanelBody
@@ -166,43 +182,47 @@ export default class Inspector extends Component {
 							}
 						/>
 					</RenderSettingControl>
-					<RenderSettingControl id="ab_postgrid_queryControls">
-						<QueryControls
-							{ ...{ order, orderBy } }
-							numberOfItems={ attributes.postsToShow }
-							categoriesList={ categoriesList }
-							selectedCategoryId={ attributes.categories }
-							onOrderChange={ ( value ) =>
-								setAttributes( { order: value } )
-							}
-							onOrderByChange={ ( value ) =>
-								setAttributes( { orderBy: value } )
-							}
-							onCategoryChange={ ( value ) =>
-								setAttributes( {
-									categories:
-										'' !== value ? value : undefined,
-								} )
-							}
-							onNumberOfItemsChange={ ( value ) =>
-								setAttributes( { postsToShow: value } )
-							}
-						/>
+					{ 'page' === attributes.postType &&
+					<RenderSettingControl id="ab_postgrid_selectedPages">
+						<div className="components-base-control select2-page">
+							<div className="components-base-control__field">
+								<label className="components-base-control__label" htmlFor="inspector-select-control">{ __( 'Pages To Show', 'atomic-blocks') }</label>
+								<Select
+									value={ JSON.parse( attributes.selectedPages ) }
+									onChange={ ( selectedOption ) => setAttributes( { selectedPages: JSON.stringify( selectedOption ) } ) }
+									options={ pageOptions }
+									isMulti={ true }
+									closeMenuOnSelect={ false }
+								/>
+							</div>
+						</div>
 					</RenderSettingControl>
-					<RenderSettingControl id="ab_postgrid_offset">
-						<RangeControl
-							label={ __(
-								'Number of items to offset',
-								'atomic-blocks'
-							) }
-							value={ attributes.offset }
-							onChange={ ( value ) =>
-								setAttributes( { offset: value } )
-							}
-							min={ 0 }
-							max={ 20 }
-						/>
-					</RenderSettingControl>
+					}
+					{ 'post' === attributes.postType &&
+					<Fragment>
+						<RenderSettingControl id="ab_postgrid_queryControls">
+							<QueryControls
+								{ ...{ order, orderBy } }
+								numberOfItems={ attributes.postsToShow }
+								categoriesList={ categoriesList }
+								selectedCategoryId={ attributes.categories }
+								onOrderChange={ ( value ) => setAttributes({ order: value }) }
+								onOrderByChange={ ( value ) => setAttributes({ orderBy: value }) }
+								onCategoryChange={ ( value ) => setAttributes({ categories: '' !== value ? value : undefined }) }
+								onNumberOfItemsChange={ ( value ) => setAttributes({ postsToShow: value }) }
+							/>
+						</RenderSettingControl>
+						<RenderSettingControl id="ab_postgrid_offset">
+							<RangeControl
+								label={ __( 'Number of items to offset', 'atomic-blocks' ) }
+								value={ attributes.offset }
+								onChange={ ( value ) => setAttributes({ offset: value }) }
+								min={ 0 }
+								max={ 20 }
+							/>
+						</RenderSettingControl>
+					</Fragment>
+					}
 					{ 'grid' === attributes.postLayout && (
 						<RenderSettingControl id="ab_postgrid_columns">
 							<RangeControl

--- a/src/blocks/block-post-grid/components/inspector.js
+++ b/src/blocks/block-post-grid/components/inspector.js
@@ -188,9 +188,13 @@ export default class Inspector extends Component {
 							<div className="components-base-control__field">
 								<label className="components-base-control__label" htmlFor="inspector-select-control">{ __( 'Pages To Show', 'atomic-blocks') }</label>
 								<Select
-									value={ JSON.parse( attributes.selectedPages ) }
-									onChange={ ( selectedOption ) => setAttributes( { selectedPages: JSON.stringify( selectedOption ) } ) }
 									options={ pageOptions }
+									value={ attributes.selectedPages }
+									onChange={ ( value ) =>
+										this.props.setAttributes( {
+											selectedPages: value,
+										} )
+									}
 									isMulti={ true }
 									closeMenuOnSelect={ false }
 								/>

--- a/src/blocks/block-post-grid/index.php
+++ b/src/blocks/block-post-grid/index.php
@@ -31,10 +31,10 @@ function atomic_blocks_render_block_core_latest_posts( $attributes ) {
 	if ( isset( $attributes['postType'] ) && 'page' === $attributes['postType'] ) {
 		/* Page query args */
 		$args = array(
-			'post_status'    => 'publish',
-			'orderby'        => 'post__in',
-			'post__in'       => $page_selection,
-			'post_type'      => 'page',
+			'post_status' => 'publish',
+			'orderby'     => 'post__in',
+			'post__in'    => $page_selection,
+			'post_type'   => 'page',
 		);
 	} else {
 		/* Post query args */
@@ -392,10 +392,10 @@ function atomic_blocks_register_block_core_latest_posts() {
 					'default' => 'post',
 				),
 				'selectedPages'       => array(
-					'type' => 'array',
+					'type'    => 'array',
 					'default' => array(),
-					'items' => [
-						'type' => 'object'
+					'items'   => [
+						'type' => 'object',
 					],
 				),
 				'sectionTag'          => array(

--- a/src/blocks/block-post-grid/index.php
+++ b/src/blocks/block-post-grid/index.php
@@ -22,34 +22,37 @@ function atomic_blocks_render_block_core_latest_posts( $attributes ) {
 	 */
 	global $post;
 
+	/* Get the post categories */
 	$categories = isset( $attributes['categories'] ) ? $attributes['categories'] : '';
 
-	// /* Get the selected pages array */
-	// $page_selection = isset( $attributes['selectedPages'] ) ? array_column( $attributes['selectedPages'], 'value' ) : null;
+	/* Get the selected pages */
+	$page_selection = isset( $attributes['selectedPages'] ) ? array_column( $attributes['selectedPages'], 'value' ) : null;
 
-	// /* Set the order based on the post type */
-	// $order_by = isset( $attributes['postType'] ) && $attributes['postType'] === 'post' ? $attributes['orderBy'] : 'post__in';
-
-	// /* Show selected pages if using the page post type */
-	// $post_in = isset( $attributes['postType'] ) && $attributes['postType'] === 'page' ? $page_selection : null;
-
-	//var_dump($attributes['selectedPages']);
-
-	/* Setup the query */
-	$grid_query = new WP_Query(
-		array(
+	if ( isset( $attributes['postType'] ) && 'page' === $attributes['postType'] ) {
+		/* Page query args */
+		$args = array(
+			'post_status'    => 'publish',
+			'orderby'        => 'post__in',
+			'post__in'       => $page_selection,
+			'post_type'      => 'page',
+		);
+	} else {
+		/* Post query args */
+		$args = array(
 			'posts_per_page'      => $attributes['postsToShow'],
 			'post_status'         => 'publish',
 			'order'               => $attributes['order'],
-			//'orderby'             => $order_by,
+			'orderby'             => $attributes['orderBy'],
 			'cat'                 => $categories,
 			'offset'              => $attributes['offset'],
-			//'post__in'            => $post_in,
 			'post_type'           => $attributes['postType'],
 			'ignore_sticky_posts' => 1,
-			'post__not_in'        => array( $post->ID ), // Exclude the current post from the grid.
-		)
-	);
+			'post__not_in'        => array( $post->ID ),
+		);
+	}
+
+	/* Setup the query */
+	$grid_query = new WP_Query( $args );
 
 	$post_grid_markup = '';
 
@@ -390,9 +393,9 @@ function atomic_blocks_register_block_core_latest_posts() {
 				),
 				'selectedPages'       => array(
 					'type' => 'array',
-					'default' => [],
+					'default' => array(),
 					'items' => [
-						'type' => 'string'
+						'type' => 'object'
 					],
 				),
 				'sectionTag'          => array(

--- a/src/blocks/block-post-grid/index.php
+++ b/src/blocks/block-post-grid/index.php
@@ -376,6 +376,10 @@ function atomic_blocks_register_block_core_latest_posts() {
 					'type'    => 'string',
 					'default' => 'post',
 				),
+				'selectedPages'       => array(
+					'type'    => 'string',
+					'default' => null,
+				),
 				'sectionTag'          => array(
 					'type'    => 'string',
 					'default' => 'section',

--- a/src/blocks/block-post-grid/index.php
+++ b/src/blocks/block-post-grid/index.php
@@ -24,14 +24,16 @@ function atomic_blocks_render_block_core_latest_posts( $attributes ) {
 
 	$categories = isset( $attributes['categories'] ) ? $attributes['categories'] : '';
 
-	/* Get the selected pages array */
-	$page_selection = isset( $attributes['selectedPages'] ) ? array_column( json_decode( $attributes['selectedPages'], true ), 'value' ) : null;
+	// /* Get the selected pages array */
+	// $page_selection = isset( $attributes['selectedPages'] ) ? array_column( $attributes['selectedPages'], 'value' ) : null;
 
-	/* Set the order based on the post type */
-	$order_by = isset( $attributes['postType'] ) && $attributes['postType'] === 'post' ? $attributes['orderBy'] : 'post__in';
+	// /* Set the order based on the post type */
+	// $order_by = isset( $attributes['postType'] ) && $attributes['postType'] === 'post' ? $attributes['orderBy'] : 'post__in';
 
-	/* Show selected pages if using the page post type */
-	$post_in = isset( $attributes['postType'] ) && $attributes['postType'] === 'page' ? $page_selection : null;
+	// /* Show selected pages if using the page post type */
+	// $post_in = isset( $attributes['postType'] ) && $attributes['postType'] === 'page' ? $page_selection : null;
+
+	//var_dump($attributes['selectedPages']);
 
 	/* Setup the query */
 	$grid_query = new WP_Query(
@@ -39,10 +41,10 @@ function atomic_blocks_render_block_core_latest_posts( $attributes ) {
 			'posts_per_page'      => $attributes['postsToShow'],
 			'post_status'         => 'publish',
 			'order'               => $attributes['order'],
-			'orderby'             => $order_by,
+			//'orderby'             => $order_by,
 			'cat'                 => $categories,
 			'offset'              => $attributes['offset'],
-			'post__in'            => $post_in,
+			//'post__in'            => $post_in,
 			'post_type'           => $attributes['postType'],
 			'ignore_sticky_posts' => 1,
 			'post__not_in'        => array( $post->ID ), // Exclude the current post from the grid.
@@ -387,8 +389,11 @@ function atomic_blocks_register_block_core_latest_posts() {
 					'default' => 'post',
 				),
 				'selectedPages'       => array(
-					'type'    => 'string',
-					'default' => null,
+					'type' => 'array',
+					'default' => [],
+					'items' => [
+						'type' => 'string'
+					],
 				),
 				'sectionTag'          => array(
 					'type'    => 'string',

--- a/src/blocks/block-post-grid/index.php
+++ b/src/blocks/block-post-grid/index.php
@@ -24,15 +24,25 @@ function atomic_blocks_render_block_core_latest_posts( $attributes ) {
 
 	$categories = isset( $attributes['categories'] ) ? $attributes['categories'] : '';
 
+	/* Get the selected pages array */
+	$page_selection = isset( $attributes['selectedPages'] ) ? array_column( json_decode( $attributes['selectedPages'], true ), 'value' ) : null;
+
+	/* Set the order based on the post type */
+	$order_by = isset( $attributes['postType'] ) && $attributes['postType'] === 'post' ? $attributes['orderBy'] : 'post__in';
+
+	/* Show selected pages if using the page post type */
+	$post_in = isset( $attributes['postType'] ) && $attributes['postType'] === 'page' ? $page_selection : null;
+
 	/* Setup the query */
 	$grid_query = new WP_Query(
 		array(
 			'posts_per_page'      => $attributes['postsToShow'],
 			'post_status'         => 'publish',
 			'order'               => $attributes['order'],
-			'orderby'             => $attributes['orderBy'],
+			'orderby'             => $order_by,
 			'cat'                 => $categories,
 			'offset'              => $attributes['offset'],
+			'post__in'            => $post_in,
 			'post_type'           => $attributes['postType'],
 			'ignore_sticky_posts' => 1,
 			'post__not_in'        => array( $post->ID ), // Exclude the current post from the grid.

--- a/src/blocks/block-post-grid/styles/editor.scss
+++ b/src/blocks/block-post-grid/styles/editor.scss
@@ -75,3 +75,11 @@
 		}
 	}
 }
+
+[data-type="atomic-blocks/ab-post-grid"] .components-placeholder {
+	align-items: center;
+
+	.components-placeholder__fieldset {
+		width: auto;
+	}
+}


### PR DESCRIPTION
<!-- A short but detailed summary of the changes. -->
Add option to select pages in the post/page grid.

### How to test
<!-- Detailed steps to test this PR. -->
1. Run `npm install` to grab the react-select package and dependencies. 
2. Compile the blocks.
3. Add the Post/Page Grid block and select the Page post type. 
4. Select pages using the select menu and test.

### Suggested changelog entry
<!-- A short description for the changelog. -->
- Add the option to select specific pages in the page grid.

### Notes
- This draft PR just covers the editor view.
- When script debug is on, react-select throws a few strict warnings. Discussion about them are happening [here](https://github.com/JedWatson/react-select/issues/3751) and [here](https://github.com/JedWatson/react-select/pull/3928). I've confirmed the latter PR fixes one of the warnings.