### PR TITLE
Fix/align controls

### DIFF
--- a/src/blocks/block-column-inner/styles/editor.scss
+++ b/src/blocks/block-column-inner/styles/editor.scss
@@ -329,3 +329,11 @@
 .ab-background-button-group {
 	margin-bottom: 25px;
 }
+
+/**
+ * Stopgap styles to improve usability of controls on full width alignment
+ */
+ [data-type="atomic-blocks/ab-columns"][data-align="full"] .block-editor-block-list__layout {
+	padding-left: 28px;
+	padding-right: 28px;
+}

--- a/src/blocks/block-container/index.js
+++ b/src/blocks/block-container/index.js
@@ -23,7 +23,7 @@ const { Component } = wp.element;
 const { registerBlockType } = wp.blocks;
 
 // Register editor components
-const { BlockControls, BlockAlignmentToolbar, InnerBlocks } = wp.blockEditor;
+const { InnerBlocks } = wp.blockEditor;
 
 const blockAttributes = {
 	containerPaddingTop: {
@@ -78,22 +78,10 @@ class ABContainerBlock extends Component {
 	render() {
 		// Setup the attributes
 		const {
-			attributes: { containerWidth },
 			setAttributes,
 		} = this.props;
 
 		return [
-			// Show the alignment toolbar on focus
-			<BlockControls key={ 'ab-container-block-controls-' + this.props.clientId } >
-				<BlockAlignmentToolbar
-					value={ containerWidth }
-					onChange={ ( containerWidth ) =>
-						setAttributes( { containerWidth } )
-					}
-					controls={ [ 'center', 'full' ] }
-				/>
-			</BlockControls>,
-
 			// Show the block controls on focus
 			<Inspector key={ 'ab-container-inspector-' + this.props.clientId } { ...{ setAttributes, ...this.props } } />,
 
@@ -120,6 +108,10 @@ registerBlockType( 'atomic-blocks/ab-container', {
 		__( 'atomic', 'atomic-blocks' ),
 	],
 
+	supports: {
+		align: [ 'center', 'wide', 'full' ]
+	},
+
 	attributes: blockAttributes,
 
 	ab_settings_data: {
@@ -129,16 +121,6 @@ registerBlockType( 'atomic-blocks/ab-container', {
 		ab_container_backgroundOptions: {
 			title: __( 'Background Options', 'atomic-blocks' ),
 		},
-	},
-
-	getEditWrapperProps( { containerWidth } ) {
-		if (
-			'left' === containerWidth ||
-			'right' === containerWidth ||
-			'full' === containerWidth
-		) {
-			return { 'data-align': containerWidth };
-		}
 	},
 
 	// Render the block components
@@ -152,6 +134,14 @@ registerBlockType( 'atomic-blocks/ab-container', {
 				<InnerBlocks.Content />
 			</Container>
 		);
+	},getEditWrapperProps( { containerWidth } ) {
+		if (
+			'center' === containerWidth ||
+			'wide' === containerWidth ||
+			'full' === containerWidth
+		) {
+			return { 'data-align': containerWidth };
+		}
 	},
 
 	deprecated,

--- a/src/blocks/block-container/styles/editor.scss
+++ b/src/blocks/block-container/styles/editor.scss
@@ -1,3 +1,11 @@
 /**
  * Editor styles for the admin
  */
+
+/**
+ * Stopgap styles to improve usability of controls on full width alignment
+ */
+ [data-type="atomic-blocks/ab-container"][data-align="full"] .block-editor-block-list__layout {
+	padding-left: 58px;
+	padding-right: 58px;
+}

--- a/src/blocks/block-layout/styles/editor.scss
+++ b/src/blocks/block-layout/styles/editor.scss
@@ -401,6 +401,9 @@ div[data-type*="atomic-blocks/ab-columns"][data-align="full"],
 div[data-type*="atomic-blocks/ab-container"][data-align="full"] {
 	margin-top: auto;
 	margin-bottom: auto;
+}
+
+div[data-type*="atomic-blocks/ab-container"][data-align="full"] .ab-block-container {
 	overflow: hidden;
 }
 

--- a/src/blocks/block-pricing-table-inner/styles/editor.scss
+++ b/src/blocks/block-pricing-table-inner/styles/editor.scss
@@ -144,3 +144,11 @@ div[data-type="atomic-blocks/ab-pricing-table-price"] .block-editor-block-list__
 .ab-block-pricing-table .block-editor-block-list__layout div:first-child .block-editor-block-list__block-edit {
 	margin-top: 0;
 }
+
+/**
+ * Stopgap styles to improve usability of controls on full width alignment
+ */
+ [data-type="atomic-blocks/ab-pricing"][data-align="full"] .block-editor-block-list__layout {
+	padding-left: 28px;
+	padding-right: 28px;
+}

--- a/src/blocks/block-pricing-table-inner/styles/style.scss
+++ b/src/blocks/block-pricing-table-inner/styles/style.scss
@@ -25,14 +25,6 @@
 	}
 }
 
-.wp-block-atomic-blocks-ab-pricing.alignfull {
-	padding: 0 2em;
-
-	@media only screen and (max-width: 600px) {
-		padding: 0 15px;
-	}
-}
-
 .ab-block-pricing-table-inside {
 	display: inline-block;
 	width: 100%;


### PR DESCRIPTION
<!-- A short but detailed summary of the changes. -->
Make adjustments to improve the inline toolbar controls. 

- Change alignment support to use `supports`. 
- Change the `overflow: hidden` to bring back the border on select.
- Add padding to the editor view to bring toggles back into the editor.

Issues were initially reported [here](https://wordpress.org/support/topic/is-the-ab-container-block-working/).

### How to test
<!-- Detailed steps to test this PR. -->
1. Pull down the branch and rebuild assets. 
2. Add the container block, add content, and make the container full width. 
3. Check that the block has a border on it when selected, and that the inline toolbars are within the viewable area on child blocks.
4. These changes have also been made to the columns block and pricing table, both of which also go full width.

### Suggested changelog entry
<!-- A short description for the changelog. -->
- Improve display of inline toolbars on Container, Columns, and Pricing Table.
- Improve display of focus/select styles on blocks.

### Notes
<!-- Additional information for reviewers. -->
