### PR TITLE
Fix notice link style

### DIFF
--- a/src/blocks/block-notice/styles/style.scss
+++ b/src/blocks/block-notice/styles/style.scss
@@ -49,17 +49,6 @@
 		border-radius: 5px;
 		background: #fff;
 
-		a {
-			color: inherit;
-			box-shadow: 0 -1px 0 inset;
-			text-decoration: none;
-
-			&:hover {
-				color: inherit;
-				box-shadow: 0 -2px 0 inset;
-			}
-		}
-
 		p:last-child {
 			margin-bottom: 0;
 		}


### PR DESCRIPTION
Defer to the theme styling instead of resetting color. This was brought up in the AB help channel in WPE Slack.

### How to test
<!-- Detailed steps to test this PR. -->
1. Activate a Genesis theme, go to Appearance -> Customize -> Colors and select a link color.
2. Add a notice block and add a link in the content area. 
3. Confirm the link color matches the color you set in the customizer.

### Suggested changelog entry
<!-- A short description for the changelog. -->
- Defer link style in Notice block to theme link styling.