### PR TITLE
check that register_block_type function exists before calling

### DIFF
--- a/src/blocks/block-newsletter/index.php
+++ b/src/blocks/block-newsletter/index.php
@@ -10,6 +10,10 @@ add_action( 'init', 'atomic_blocks_register_newsletter_block' );
  * Registers the newsletter block.
  */
 function atomic_blocks_register_newsletter_block() {
+	/* Check if the register function exists */
+	if ( ! function_exists( 'register_block_type' ) ) {
+		return;
+	}
 
 	register_block_type(
 		'atomic-blocks/newsletter',


### PR DESCRIPTION
Installing and activating the plugin threw an error when attempting to call the function "register_block_type".
