### PR TITLE
Support custom CSS classes in columns

### DIFF
--- a/src/blocks/block-column/components/save.js
+++ b/src/blocks/block-column/components/save.js
@@ -15,6 +15,7 @@ export default class Save extends Component {
 		const { attributes } = this.props;
 
 		const className = classnames( [
+			this.props.className,
 			'ab-layout-column-wrap',
 			'ab-block-layout-column-gap-' + attributes.columnsGap,
 			attributes.responsiveToggle ? 'ab-is-responsive-column' : null,


### PR DESCRIPTION
<!-- A short but detailed summary of the changes. -->
Advanced columns did not include "Additional CSS classes" in the styles. This fixes the missing style classes.
