### PR TITLE
Show column setting when using Page Grid.

### DIFF
--- a/src/blocks/block-post-grid/styles/editor.scss
+++ b/src/blocks/block-post-grid/styles/editor.scss
@@ -8,10 +8,6 @@
 	}
  }
 
- .atomic-blocks-hide-query .components-base-control:nth-of-type(3) {
-	 display: none;
- }
-
  .ab-block-post-grid-markup-settings {
 	 .components-base-control__help {
 		 margin-top: 8px;


### PR DESCRIPTION
<!-- A short but detailed summary of the changes. -->
Some old CSS was hiding the column setting when choosing pages in the Post/Page Grid. The solution also requires [a fix in Genesis Page Builder](https://github.com/studiopress/genesis-page-builder/pull/56).

Fixes #370 

### How to test
<!-- Detailed steps to test this PR. -->
1. Pull down branch and build assets. 
2. Grab the matching branch from GPB. 
3. Add the Post Grid block, change to Page type, and ensure the column setting is visible and working.

### Suggested changelog entry
<!-- A short description for the changelog. -->
- Make column setting visible when working with pages in the Post and Page Grid block.

### Notes
<!-- Additional information for reviewers. -->
This PR has a matching [PR in Genesis Page Builder](https://github.com/studiopress/genesis-page-builder/pull/56).