### PR TITLE
Be more specific about loader.php location

### DIFF
--- a/atomicblocks.php
+++ b/atomicblocks.php
@@ -43,5 +43,5 @@ if ( ! function_exists( 'atomic_blocks_main_plugin_file' ) ) {
 	}
 
 	// Load the rest of the plugin.
-	require_once 'loader.php';
+	require_once plugin_dir_path( __FILE__ ) . 'loader.php';
 }


### PR DESCRIPTION
This makes the file path to loader.php more explicit. This fixes an issue where, under certain conditions, the plugin's loader.php would not be loaded on the front end of the site.

Reported in support here: https://wordpress.org/support/topic/no-css-being-read-from-ab/

I tracked this down and tested the fix on the user's site to confirm.
