### PR TITLE
Post/Page Grid block: Adds posts_per_page parameter to Page queries.

### DIFF
--- a/src/blocks/block-post-grid/components/edit.js
+++ b/src/blocks/block-post-grid/components/edit.js
@@ -56,7 +56,7 @@ class LatestPostsBlock extends Component {
 
 		// Removing posts from display should be instant.
 		const displayPosts =
-			( latestPosts.length > attributes.postsToShow ) && attributes.postType === 'posts'
+			( latestPosts.length > attributes.postsToShow ) && attributes.postType === 'post'
 				? latestPosts.slice( 0, attributes.postsToShow )
 				: latestPosts;
 

--- a/src/blocks/block-post-grid/components/edit.js
+++ b/src/blocks/block-post-grid/components/edit.js
@@ -56,7 +56,7 @@ class LatestPostsBlock extends Component {
 
 		// Removing posts from display should be instant.
 		const displayPosts =
-			latestPosts.length > attributes.postsToShow
+			( latestPosts.length > attributes.postsToShow ) && attributes.postType === 'posts'
 				? latestPosts.slice( 0, attributes.postsToShow )
 				: latestPosts;
 
@@ -295,6 +295,7 @@ export default compose( [
 			{
 				include: pageIDs ? pageIDs : null,
 				orderby: pageIDs ? 'include' : null,
+				per_page: props.attributes.selectedPages.length
 			},
 			( value ) => ! isUndefined( value )
 		);

--- a/src/blocks/block-post-grid/index.php
+++ b/src/blocks/block-post-grid/index.php
@@ -26,16 +26,18 @@ function atomic_blocks_render_block_core_latest_posts( $attributes ) {
 	$categories = isset( $attributes['categories'] ) ? $attributes['categories'] : '';
 
 	/* Get the selected pages */
-	$page_selection = isset( $attributes['selectedPages'] ) ? array_column( $attributes['selectedPages'], 'value' ) : null;
+	$page_selection = isset( $attributes['selectedPages'] ) ? array_column( $attributes['selectedPages'], 'value' ) : [];
 
 	if ( isset( $attributes['postType'] ) && 'page' === $attributes['postType'] ) {
 		/* Page query args */
 		$args = array(
-			'post_status' => 'publish',
-			'orderby'     => 'post__in',
-			'post__in'    => $page_selection,
-			'post_type'   => 'page',
+			'post_status'    => 'publish',
+			'orderby'        => 'post__in',
+			'post__in'       => $page_selection,
+			'post_type'      => 'page',
+			'posts_per_page' => count( $page_selection ),
 		);
+
 	} else {
 		/* Post query args */
 		$args = array(


### PR DESCRIPTION
Adds post_per_page parameter to WP_Query args when Content Type is set to Page.

If we do not provide the parameter, WP_Query will default to
the get_option( 'posts_per_page' ) value. If this value is
smaller than the number of pages selected to display in the
block, it results in only part of the user's selections
showing.

Fixes #389.

### How to test

1. Go to Settings > Reading in wp-admin.
2. Set the option named "Blog pages show at most" to a low value, like 2 or 3, and save.
3. Add Post and Page Grid block to a page.
4. Configure the block so that Content Type is set to Page.
5. Select numerous Pages in the Pages to Show dropdown. Make sure the number is higher than the value you saved in step 2 above.
6. Publish the page and view it.
7. Ensure all the Pages you selected to show are showing.

### Suggested changelog entry
- Fixes issue where all pages selected in the Post and Page Grid block might not be displayed.

### Notes
<!-- Additional information for reviewers. -->
