### PR TITLE
Rename "Genesis Page Builder" to "Genesis Blocks Pro".

### DIFF
--- a/dist/getting-started/getting-started.css
+++ b/dist/getting-started/getting-started.css
@@ -14,12 +14,14 @@
 }
 
 .toplevel_page_atomic-blocks #update-nag,
+.genesis-blocks_page_atomic-blocks-plugin-settings #update-nag,
 .page-builder_page_atomic-blocks-plugin-settings #update-nag,
 .atomic-blocks_page_atomic-blocks-plugin-settings #update-nag {
 	display: none !important;
 }
 
 .toplevel_page_atomic-blocks #wpcontent,
+.genesis-blocks_page_atomic-blocks-plugin-settings #wpcontent,
 .page-builder_page_atomic-blocks-plugin-settings #wpcontent,
 .atomic-blocks_page_atomic-blocks-plugin-settings #wpcontent {
 	padding-left: 0;

--- a/dist/getting-started/getting-started.php
+++ b/dist/getting-started/getting-started.php
@@ -13,7 +13,7 @@
  */
 function atomic_blocks_start_load_admin_scripts( $hook ) {
 
-	if ( ! in_array( $hook, [ 'page-builder_page_atomic-blocks-plugin-settings', 'toplevel_page_atomic-blocks' ], true ) ) {
+	if ( ! in_array( $hook, [ 'genesis-blocks_page_atomic-blocks-plugin-settings', 'page-builder_page_atomic-blocks-plugin-settings', 'toplevel_page_atomic-blocks' ], true ) ) {
 		return;
 	}
 
@@ -47,8 +47,8 @@ function atomic_blocks_getting_started_menu() {
 	$icon_url   = 'dashicons-screenoptions';
 
 	if ( atomic_blocks_is_pro() ) {
-		$page_title = esc_html__( 'Genesis Page Builder Settings', 'atomic-blocks' );
-		$menu_title = esc_html__( 'Page Builder', 'atomic-blocks' );
+		$page_title = esc_html__( 'Genesis Blocks Pro Settings', 'atomic-blocks' );
+		$menu_title = esc_html__( 'Genesis Blocks', 'atomic-blocks' );
 		$icon_url   = esc_url( plugins_url( '/dist/getting-started/images/genesis-menu.png', atomic_blocks_main_plugin_file() ) );
 	}
 
@@ -210,7 +210,7 @@ function atomic_blocks_save_settings() {
  */
 function atomic_blocks_load_settings_page_scripts( $hook ) {
 
-	if ( ! in_array( $hook, [ 'page-builder_page_atomic-blocks-plugin-settings', 'atomic-blocks_page_atomic-blocks-plugin-settings' ], true ) ) {
+	if ( ! in_array( $hook, [ 'genesis-blocks_page_atomic-blocks-plugin-settings', 'page-builder_page_atomic-blocks-plugin-settings', 'atomic-blocks_page_atomic-blocks-plugin-settings' ], true ) ) {
 		return;
 	}
 

--- a/dist/init.php
+++ b/dist/init.php
@@ -128,7 +128,7 @@ function atomic_blocks_add_custom_block_category( $categories ) {
 	$category_title = __( 'Atomic Blocks', 'atomic-blocks' );
 
 	if ( atomic_blocks_is_pro() ) {
-		$category_title = __( 'Genesis Page Builder', 'atomic-blocks' );
+		$category_title = __( 'Genesis Blocks', 'atomic-blocks' );
 	}
 
 	return array_merge(

--- a/src/blocks/block-layout/components/layout/layout-modal.js
+++ b/src/blocks/block-layout/components/layout/layout-modal.js
@@ -56,7 +56,6 @@ class LayoutModal extends Component {
 				<Button
 					key={ 'layout-modal-library-button-' + this.props.clientId }
 					isPrimary
-					isLarge
 					className="ab-layout-modal-button"
 					onClick={ () =>
 						this.setState( {


### PR DESCRIPTION
- Updates admin sidebar menu label.
- Updates conditionals that gate CSS and JS loading on Getting Started Page.
- Updates the Getting Started page CSS to account for the new dynamic classes generated by WP because of the rename.
