### PR TITLE
Fixes issue where automatic excerpts are not displayed.

### DIFF
--- a/src/blocks/block-post-grid/index.php
+++ b/src/blocks/block-post-grid/index.php
@@ -112,12 +112,12 @@ function atomic_blocks_render_block_core_latest_posts( $attributes ) {
 				'<div class="ab-block-post-grid-text">'
 			);
 
-				$post_grid_markup .= sprintf(
-					'<header class="ab-block-post-grid-header">'
-				);
+			$post_grid_markup .= sprintf(
+				'<header class="ab-block-post-grid-header">'
+			);
 
-					/* Get the post title */
-					$title = get_the_title( $post_id );
+			/* Get the post title */
+			$title = get_the_title( $post_id );
 
 			if ( ! $title ) {
 				$title = __( 'Untitled', 'atomic-blocks' );
@@ -156,11 +156,11 @@ function atomic_blocks_render_block_core_latest_posts( $attributes ) {
 
 				/* Get the post date */
 				if ( isset( $attributes['displayPostDate'] ) && $attributes['displayPostDate'] ) {
-						$post_grid_markup .= sprintf(
-							'<time datetime="%1$s" class="ab-block-post-grid-date" itemprop="datePublished">%2$s</time>',
-							esc_attr( get_the_date( 'c', $post_id ) ),
-							esc_html( get_the_date( '', $post_id ) )
-						);
+					$post_grid_markup .= sprintf(
+						'<time datetime="%1$s" class="ab-block-post-grid-date" itemprop="datePublished">%2$s</time>',
+						esc_attr( get_the_date( 'c', $post_id ) ),
+						esc_html( get_the_date( '', $post_id ) )
+					);
 				}
 
 				/* Close the byline content */
@@ -175,44 +175,47 @@ function atomic_blocks_render_block_core_latest_posts( $attributes ) {
 			);
 
 			/* Wrap the excerpt content */
-			$post_grid_markup .= sprintf(
-				'<div class="ab-block-post-grid-excerpt">'
-			);
+			$post_grid_markup .= '<div class="ab-block-post-grid-excerpt">';
 
 			/* Get the excerpt */
+			if ( isset( $attributes['displayPostExcerpt'] ) && $attributes['displayPostExcerpt'] ) {
 
-			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound, PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket
-			$excerpt = apply_filters( 'the_excerpt',
-				get_post_field(
+				// Check for a manual excerpt.
+				$excerpt = get_post_field(
 					'post_excerpt',
 					$post_id,
 					'display'
-				)
-			);
-
-			if ( empty( $excerpt ) && isset( $attributes['excerptLength'] ) ) {
-				// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound, PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket  -- Running the_excerpt directly, Previous rule doesn't take without the_excerpt being moved up a line
-				$excerpt = apply_filters( 'the_excerpt',
-					wp_trim_words(
-						preg_replace(
-							array(
-								'/\<figcaption>.*\<\/figcaption>/',
-								'/\[caption.*\[\/caption\]/',
-							),
-							'',
-							get_the_content()
-						),
-						$attributes['excerptLength']
-					)
 				);
-			}
 
-			if ( ! $excerpt ) {
-				$excerpt = null;
-			}
+				/**
+				 * Create an automatic excerpt
+				 * if a manual one does not exist.
+				 */
+				if ( empty( $excerpt ) ) {
+					$excerpt = preg_replace(
+						array(
+							'/\<figcaption>.*\<\/figcaption>/',
+							'/\[caption.*\[\/caption\]/',
+						),
+						'',
+						get_the_content()
+					);
+				}
 
-			if ( isset( $attributes['displayPostExcerpt'] ) && $attributes['displayPostExcerpt'] ) {
-				$post_grid_markup .= wp_kses_post( $excerpt );
+				// Trim the excerpt if necessary.
+				if ( isset( $attributes['excerptLength'] ) ) {
+					$excerpt = wp_trim_words(
+						$excerpt,
+						$attributes['excerptLength']
+					);
+				}
+
+				// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- This is a WP core filter.
+				$excerpt = apply_filters( 'the_excerpt', $excerpt );
+
+				if ( ! empty( $excerpt ) ) {
+					$post_grid_markup .= wp_kses_post( $excerpt );
+				}
 			}
 
 			/* Get the read more link */
@@ -225,18 +228,8 @@ function atomic_blocks_render_block_core_latest_posts( $attributes ) {
 				);
 			}
 
-			/* Close the excerpt content */
-			$post_grid_markup .= sprintf(
-				'</div>'
-			);
-
-			/* Close the text content */
-			$post_grid_markup .= sprintf(
-				'</div>'
-			);
-
-			/* Close the post */
-			$post_grid_markup .= "</article>\n";
+			/* Close the excerpt content, text, and post wrappers */
+			$post_grid_markup .= "</div></div></article>\n";
 		}
 
 		/* Restore original post data */


### PR DESCRIPTION
The previous logic checked to see if the manual excerpt was empty before
generating one automatically. The problem was when checking for a
manual excerpt, it passed the data through the `the_excerpt` filter.
In cases where themes or plugins filtered `the_excerpt`, this caused
our empty check to assume there was a manual excerpt, therefore no
automatic excerpt was generated. An example of where this can
happen is with social sharing plugins that use the filter to add
sharing links/buttons.

This changes the logic so that it passes the data through
`the_excerpt` later, which avoids this issue.

Additional changes:
* Only checks for excerpts when the block is configured to show them.

### How to test
<!-- Detailed steps to test this PR. -->
1. Check out `master` branch.
2. Configure the Post Grid block to show excerpts.
3. Be sure some posts have manual excerpts and some do not have them.
4. Note that excerpts should show as expected.
5. Add the following code to your site and test excerpts again:
```
add_action( 'the_excerpt', function( $excerpt ) {
    return 'moo ' . $excerpt;
} );
```
6. Note that automatic excerpts are broken.
7. Check out this branch.
8. Do above tests again.
9. Be sure nothing else broke!

### Suggested changelog entry
- Fixed issue with the Post & Page Grid block where automatic excerpts did not show under certain conditions.

