### PR TITLE
Remove deprecated isLarge prop from Button

### DIFF
--- a/src/blocks/block-layout/components/layout/layout-modal.js
+++ b/src/blocks/block-layout/components/layout/layout-modal.js
@@ -56,7 +56,6 @@ class LayoutModal extends Component {
 				<Button
 					key={ 'layout-modal-library-button-' + this.props.clientId }
 					isPrimary
-					isLarge
 					className="ab-layout-modal-button"
 					onClick={ () =>
 						this.setState( {


### PR DESCRIPTION
Removes deprecated property to fix e2e failures per https://github.com/studiopress/atomic-blocks/pull/398#pullrequestreview-488765457

