### PR TITLE
Fix full-width container editor padding in WP 5.5

### DIFF
--- a/src/blocks/block-column-inner/styles/editor.scss
+++ b/src/blocks/block-column-inner/styles/editor.scss
@@ -331,16 +331,3 @@
 .ab-background-button-group {
 	margin-bottom: 25px;
 }
-
-/**
- * Stopgap styles to improve usability of controls on full width alignment
- */
-[data-type="atomic-blocks/ab-columns"][data-align="full"] .ab-layout-column-wrap-admin > .block-editor-inner-blocks > .block-editor-block-list__layout {
-	padding-left: 58px;
-	padding-right: 58px;
-}
-
-[data-type="atomic-blocks/ab-columns"][data-align="full"] .ab-layout-column-wrap-admin > .block-editor-inner-blocks > .block-editor-block-list__layout .block-editor-block-list__layout {
-	padding-left: 0;
-	padding-right: 0;
-}

--- a/src/blocks/block-container/styles/editor.scss
+++ b/src/blocks/block-container/styles/editor.scss
@@ -2,14 +2,6 @@
  * Editor styles for the admin
  */
 
-/**
- * Stopgap styles to improve usability of controls on full width alignment
- */
- [data-type="atomic-blocks/ab-container"][data-align="full"] .ab-container-content > .block-editor-inner-blocks > .block-editor-block-list__layout {
-	padding-left: 58px;
-	padding-right: 58px;
-}
-
 .ab-container-inspector-media {
 	padding: 8px;
 }

--- a/src/blocks/block-pricing-table-inner/styles/editor.scss
+++ b/src/blocks/block-pricing-table-inner/styles/editor.scss
@@ -145,14 +145,6 @@ div[data-type="atomic-blocks/ab-pricing-table-price"] .block-editor-block-list__
 	margin-top: 0;
 }
 
-/**
- * Stopgap styles to improve usability of controls on full width alignment
- */
- [data-type="atomic-blocks/ab-pricing"][data-align="full"] .ab-pricing-table-wrap-admin > .block-editor-inner-blocks > .block-editor-block-list__layout {
-	padding-left: 58px;
-	padding-right: 58px;
-}
-
 .ab-pricing-table-button .ab-block-button .components-button {
 	padding: 8px;
 }


### PR DESCRIPTION
Ensures that full width container, pricing, and advanced column blocks do not have additional padding in the editor under WordPress 5.5.

Applies the same fix @dreamwhisper made to Genesis Blocks in https://github.com/studiopress/genesis-blocks/pull/45.

Fixes #395.

### How to test
Under WP 5.5+.

1. Add a container, pricing, and advanced column block.
2. Set each to full-width.
3. In the editor, check that there is not excessive padding to the left and right of the blocks.

### Suggested changelog entry
- Removed unnecessary padding in the editor on full-width Container, Pricing, and Advanced Column blocks.