### PR TITLE
Make column count work under WordPress 5.5

### DIFF
--- a/src/blocks/block-column-inner/components/edit.js
+++ b/src/blocks/block-column-inner/components/edit.js
@@ -70,6 +70,7 @@ class Edit extends Component {
 				key="column"
 			>
 				<InnerBlocks
+					template={[[ 'core/paragraph' ]]}
 					templateLock={ false }
 					templateInsertUpdatesSelection={ false }
 				/>

--- a/src/blocks/block-column/components/edit.js
+++ b/src/blocks/block-column/components/edit.js
@@ -16,6 +16,7 @@ import _times from 'lodash/times';
 const { __ } = wp.i18n;
 const { Component, Fragment } = wp.element;
 const { compose } = wp.compose;
+const { dispatch } = wp.data;
 const {
 	BlockControls,
 	BlockAlignmentToolbar,
@@ -45,6 +46,12 @@ class Edit extends Component {
 		this.state = {
 			selectLayout: true
 		};
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( this.props.attributes.columns !== prevProps.attributes.columns ) {
+			dispatch( 'core/block-editor' ).synchronizeTemplate();
+		}
 	}
 
 	render() {

--- a/src/blocks/block-pricing-table/index.js
+++ b/src/blocks/block-pricing-table/index.js
@@ -21,6 +21,8 @@ const { registerBlockType } = wp.blocks;
 // Register editor components
 const { BlockControls, BlockAlignmentToolbar, InnerBlocks } = wp.blockEditor;
 
+const { dispatch } = wp.data;
+
 // Set allowed blocks and media
 const ALLOWED_BLOCKS = [ 'atomic-blocks/ab-pricing-table' ];
 
@@ -30,6 +32,13 @@ const getPricingTemplate = memoize( ( columns ) => {
 } );
 
 class ABPricingBlock extends Component {
+
+	componentDidUpdate( prevProps ) {
+		if ( this.props.attributes.columns !== prevProps.attributes.columns ) {
+			dispatch( 'core/block-editor' ).synchronizeTemplate();
+		}
+	}
+
 	render() {
 		// Setup the attributes
 		const {


### PR DESCRIPTION
Fixes https://github.com/studiopress/atomic-blocks/issues/397 for WP 5.5 so that:

- New columns in the advanced column block display placeholder text.
- Increasing the number of columns in the Advanced Columns and Pricing blocks shows new columns.

Applies the same fixes already tested and deployed in Genesis Blocks:

- https://github.com/studiopress/genesis-blocks/pull/51
- https://github.com/studiopress/genesis-blocks/pull/54
- https://github.com/studiopress/genesis-blocks/pull/55

### How to test
Under WP 5.5+:

1. Add a pricing block with 2 columns.
2. Increase the column count to 3. You should see three columns.
3. Add an advanced columns block with 2 columns. You should see placeholder content for all columns.
4. Increase the column count to 3. You should see three columns with placeholder content in the third.

### Suggested changelog entry
- Advanced Columns and Pricing blocks now show new columns when the column count is increased in WordPress 5.5.
- Placeholder text in the Advanced Columns block is now visible in WordPress 5.5.