### PR TITLE
Use “Install and Activate Genesis Blocks” for button label to better set expectations

### DIFF
--- a/dist/migration/migrate-page/ab-migrate.php
+++ b/dist/migration/migrate-page/ab-migrate.php
@@ -32,7 +32,7 @@
 							if ( PHP_VERSION_ID >= 70100 ) {
 								?>
 								<p><?php esc_html_e( 'With our migration tool built right into Genesis Blocks, the transition between plugins will be simple and seamless - plus you\'ll be ready to receive the new blocks and features we\'re releasing soon.', 'atomic-blocks' ); ?></p>
-								<button id="atomic-blocks-install-genesis-blocks-button" class="button-primary"><?php esc_html_e( 'Install Genesis Blocks', 'atomic-blocks' ); ?></button>
+								<button id="atomic-blocks-install-genesis-blocks-button" class="button-primary"><?php esc_html_e( 'Install and Activate Genesis Blocks', 'atomic-blocks' ); ?></button>
 								<div id="atomic-blocks-install-genesis-blocks-spinner" class="spinner" style="float:none"></div>
 								<div id="atomic-blocks-install-genesis-blocks-error-message" class="migrate-error-message" style="display:none;"><?php echo esc_html( __( 'Something went wrong. Try again.', 'atomic-blocks' ) ); ?></div>
 								<div id="atomic-blocks-install-genesis-blocks-success-message" class="migrate-success-message" style="display:none;"><?php echo esc_html( __( 'Successfully installed and activated Genesis Blocks!', 'atomic-blocks' ) ); ?></div>


### PR DESCRIPTION
Feedback from @robstino and @lukecarbis at https://github.com/studiopress/genesis-blocks/pull/112#issuecomment-706780635 suggested updating the button label to make it more clear that GB will be installed _and activated_.

## Before

<img width="817" alt="Screenshot 2020-10-12 at 14 44 40" src="https://user-images.githubusercontent.com/647669/95747908-7b1d9d00-0c99-11eb-88c8-b50cc8be5c3a.png">

## After

<img width="801" alt="Screenshot 2020-10-12 at 14 43 22" src="https://user-images.githubusercontent.com/647669/95747819-56c1c080-0c99-11eb-8eb4-2efce7958319.png">

### Documentation
Tagging @susannelson for visibility because this has an impact on any screenshots taken so far.