### PR TITLE
Add additional migration notice for GB 1.0 users

### DIFF
--- a/dist/migration/migrate-page/ab-migrate.php
+++ b/dist/migration/migrate-page/ab-migrate.php
@@ -36,6 +36,10 @@
 								<div id="atomic-blocks-install-genesis-blocks-spinner" class="spinner" style="float:none"></div>
 								<div id="atomic-blocks-install-genesis-blocks-error-message" class="migrate-error-message" style="display:none;"><?php echo esc_html( __( 'Something went wrong. Try again.', 'atomic-blocks' ) ); ?></div>
 								<div id="atomic-blocks-install-genesis-blocks-success-message" class="migrate-success-message" style="display:none;"><?php echo esc_html( __( 'Successfully installed and activated Genesis Blocks!', 'atomic-blocks' ) ); ?></div>
+								<p>
+									<strong><?php esc_html_e( 'Already using Genesis Blocks?', 'atomic-blocks' ); ?> </strong>
+									<?php esc_html_e( 'Update to 1.1.0+ and visit Genesis Blocks → Migrate to begin your migration.', 'atomic-blocks' ); ?>
+								</p>
 								<?php
 							} else {
 								?>


### PR DESCRIPTION
To encourage Genesis Blocks 1.0 users to update to Genesis Blocks 1.1.

<img width="1025" alt="Screenshot 2020-10-12 at 18 53 29" src="https://user-images.githubusercontent.com/647669/95771987-4ff87500-0cbc-11eb-8f79-f38a75e6ca08.png">

@susannelson discovered that Genesis Blocks 1.0 users who click the “Install and Activate Genesis Blocks” button at Atomic Blocks → Migrate see a “you do not have permission to access this page” message when they are redirected to the Genesis Blocks migrate page. That page only exists if they are running Genesis Blocks 1.1, and the current migration process only activates an existing copy of Genesis Blocks — it does not attempt to update it to the latest version from WP.org.

This PR adds some additional text to prompt such users to update.

### How to test
Review text at Atomic Blocks → Migrate.

### Documentation
@susannelson Does the new text help to address this issue, or do you recommend further changes? 

### Notes
An alternative to displaying text is to attempt to detect the presence of Genesis Blocks, store its version, and then change the button action:

- If GB version is <1.1: update the plugin to GB 1.1+ (if safe/possible?), activate GB, then redirect to the migration page. OR: show a prompt instead of a button and link to the Plugin Update page.
- If GB version is >1.1: activate GB and redirect to the migration page [current behaviour].

We chose to add some text because it's an edge case (there are more people using AB alone than AB plus GB), but happy to adjust this or pick another approach if needed.