### PR TITLE
Update the migration admin-notice with a more suitable message

### DIFF
--- a/dist/migration/class-notice.php
+++ b/dist/migration/class-notice.php
@@ -83,39 +83,21 @@ class Notice {
 		$migration_url = admin_url( 'admin.php?page=atomic-blocks-migrate-page' );
 
 		?>
-		<div id="ab-migration-notice" class="notice notice-info ab-notice-migration">
+		<div id="ab-migration-notice" class="notice notice-warning ab-notice-migration">
 			<?php wp_nonce_field( self::NOTICE_NONCE_ACTION, self::NOTICE_NONCE_NAME, false ); ?>
 			<div class="ab-migration-copy">
 				<p>
 					<?php
-					printf(
-						/* translators: %1$s: the plugin name */
-						esc_html__( 'Atomic Blocks has moved! For future updates and improvements, migrate now to the new home of site building with Gutenberg: %1$s.', 'atomic-blocks' ),
-						sprintf(
-							'<strong>%1$s</strong>',
-							esc_html__( 'Genesis Blocks', 'atomic-blocks' )
-						)
-					);
+						esc_html_e( "Atomic Blocks has been renamed to Genesis Blocks and will no longer be maintained. It's time to migrate to the new plugin, which is free and easy to do! Visit the Migrate page to learn more and begin the migration.", 'atomic-blocks' );
 					?>
 					<a rel="noopener noreferrer" class="ab-notice-migration__learn-more" href="<?php echo esc_url( $migration_url ); ?>">
 						<?php esc_html_e( 'Learn more about migrating', 'atomic-blocks' ); ?>
 					</a>
 				</p>
 			</div>
-			<button id="ab-notice-not-now" href="#" class="ab-notice-option button button-secondary">
-				<?php esc_html_e( 'Not Now', 'atomic-blocks' ); ?>
-			</button>
 			<a href="<?php echo esc_url( $migration_url ); ?>" class="ab-notice-option button button-primary">
 				<?php esc_html_e( 'Migrate', 'atomic-blocks' ); ?>
 			</a>
-		</div>
-		<div id="ab-not-now-notice" class="notice notice-info ab-notice-migration ab-hidden">
-			<div class="ab-migration-copy">
-				<p><?php esc_html_e( "When you're ready, our migration tool is available in the main menu, under Atomic Blocks > Migrate.", 'atomic-blocks' ); ?></p>
-			</div>
-			<button id="ab-notice-ok" class="ab-notice-option button">
-				<?php esc_html_e( 'Okay', 'atomic-blocks' ); ?>
-			</button>
 		</div>
 		<?php
 	}

--- a/dist/migration/class-notice.php
+++ b/dist/migration/class-notice.php
@@ -139,12 +139,6 @@ class Notice {
 			return false;
 		}
 
-		// If the user has dismissed the notice, it should reappear in 2 weeks.
-		$time_dismissed = get_user_meta( get_current_user_id(), self::NOTICE_USER_META_KEY, true );
-		if ( ! empty( $time_dismissed ) && ( $time_dismissed + WEEK_IN_SECONDS * 2 > time() ) ) {
-			return false;
-		}
-
 		$screen = get_current_screen();
 		return ( isset( $screen->base ) && in_array( $screen->base, array( 'plugins', 'dashboard', 'atomic-blocks', 'atomic-blocks-plugin-settings' ), true ) );
 	}


### PR DESCRIPTION
<!-- A short but detailed summary of the changes. -->
This PR updates the Migration admin notice so it have a more suitable message to help users understand that this plugin is not going to receive any updates in the future.
<!-- Fixes #xxx. -->
<!-- See #xxx. -->

### How to test
<!-- Detailed steps to test this PR. -->
1. Download this branch
2. Run `composer install` and `npm install`
3. Run `npm start` and check the wp-admin. You should see a new message as a not dismissible admin notice.

![Screen Shot 2022-01-06 at 13 20 38](https://user-images.githubusercontent.com/4185923/148807743-f2376bca-a6e8-4fa6-ad3d-805516b34761.png)

### Documentation
<!-- No documentation required. -->
<!-- Documentation required. See #xxx. -->
<!-- PR includes documentation. -->

### Suggested changelog entry
<!-- A short description for the changelog. -->
- Update the migration admin notice message

### Notes
<!-- Additional information for reviewers. -->
